### PR TITLE
feat: replace watershed segmentation with cellpose

### DIFF
--- a/configurations/CRC33_01.yaml
+++ b/configurations/CRC33_01.yaml
@@ -28,11 +28,8 @@ preprocessing:
     upper_quantile: 0.995
 
 segmentation:
-  gaussian_sigma: 1.2
-  minimum_nucleus_area_pixels: 60
-  maximum_nucleus_area_pixels: 1500
-  peak_minimum_distance_pixels: 6
-  cell_expansion_distance_pixels: 6
+  cell_diameter_pixels: null
+  use_gpu: false
 
 normalization:
   arcsinh_cofactor: 150.0
@@ -43,19 +40,19 @@ normalization:
 
 annotation:
   cell_types:
-    - name: Tumor
+    - name: epithelial cell
       positive_markers: [Pan-CK]
-    - name: Endothelial
+    - name: endothelial cell
       positive_markers: [CD31]
-    - name: Stromal
+    - name: stromal cell
       positive_markers: [SMA]
-    - name: B_cell
+    - name: B cell
       positive_markers: [CD20]
-    - name: T_cell
+    - name: T cell
       positive_markers: [CD3e]
-    - name: Macrophage
+    - name: macrophage
       positive_markers: [CD68]
-    - name: Treg
+    - name: regulatory T cell
       positive_markers: [CD4, FOXP3]
 
 spatial_analysis:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "cellpose>=4.1.1",
     "imagecodecs>=2026.1.14",
     "matplotlib>=3.10.8",
     "numpy>=2.2.2",

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
+import pydantic
 import yaml
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import BaseModel, Field, model_validator
 
-from src.data_models import RegionOfInterestBox
 from src.io import read_marker_names
 
 
@@ -48,16 +47,12 @@ class PreprocessingConfiguration(BaseModel):
 
 
 class SegmentationConfiguration(BaseModel):
-    gaussian_sigma: float = 1.2
-    minimum_nucleus_area_pixels: int = 60
-    maximum_nucleus_area_pixels: int = 1500
-    peak_minimum_distance_pixels: int = 6
-    cell_expansion_distance_pixels: int = 6
+    cell_diameter_pixels: float | None = None
+    use_gpu: bool = False
 
 
 class NormalizationConfiguration(BaseModel):
     arcsinh_cofactor: float = 150.0
-    threshold_method: str = "otsu_with_fallback"
     positive_fraction_minimum: float = 0.005
     positive_fraction_maximum: float = 0.70
     fallback_quantile: float = 0.90
@@ -65,8 +60,6 @@ class NormalizationConfiguration(BaseModel):
 
 class SpatialAnalysisConfiguration(BaseModel):
     nearest_neighbor_count: int = 10
-    minimum_cells_per_type_for_pairwise_analysis: int = 25
-    minimum_cells_per_type_for_clustering: int = 50
     permutation_count: int = 100
     neighborhood_cluster_count: int = 6
 
@@ -94,6 +87,7 @@ class ApplicationConfiguration(BaseModel):
 
     @model_validator(mode="after")
     def validate_configuration_paths(self) -> "ApplicationConfiguration":
+        """Verify that all configured input file paths exist on disk."""
         required_paths = [self.input_paths.readouts, self.input_paths.markers]
         for required_path in required_paths:
             if not required_path.exists():
@@ -105,8 +99,10 @@ class ApplicationConfiguration(BaseModel):
         return self
 
     def validate_marker_names(
-        self, marker_names: list[str]
+        self,
+        marker_names: list[str],
     ) -> "ApplicationConfiguration":
+        """Check that all configured marker references resolve to markers in the panel file."""
         allowed_marker_names = set(marker_names)
         for required_marker_name in [
             self.channels.nuclear_marker,
@@ -156,14 +152,17 @@ class ApplicationConfiguration(BaseModel):
 
     @property
     def marker_names(self) -> list[str]:
+        """Read marker names from the configured markers file."""
         return read_marker_names(self.input_paths.markers)
 
     @property
     def sample_output_directory(self) -> Path:
+        """Return the per-sample output directory path."""
         return self.output_directory / self.sample_identifier
 
     @property
     def annotation_marker_names(self) -> list[str]:
+        """Return deduplicated, insertion-ordered marker names used across all annotation rules."""
         seen_marker_names: set[str] = set()
         ordered_marker_names: list[str] = []
         for cell_type_rule in self.annotation.cell_types:
@@ -174,32 +173,14 @@ class ApplicationConfiguration(BaseModel):
         return ordered_marker_names
 
 
-def convert_model_to_dictionary(
-    model: BaseModel | dict[str, Any] | list[Any] | Any,
-) -> Any:
-    if isinstance(model, BaseModel):
-        return {
-            key: convert_model_to_dictionary(value)
-            for key, value in model.model_dump().items()
-        }
-    if isinstance(model, Path):
-        return str(model)
-    if isinstance(model, RegionOfInterestBox):
-        return model.as_dictionary()
-    if isinstance(model, dict):
-        return {key: convert_model_to_dictionary(value) for key, value in model.items()}
-    if isinstance(model, list):
-        return [convert_model_to_dictionary(value) for value in model]
-    return model
-
-
 def load_configuration(path: str | Path) -> ApplicationConfiguration:
+    """Load and validate an application configuration from a YAML file."""
     configuration_path = Path(path)
     with configuration_path.open("r", encoding="utf-8") as file_handle:
         configuration_payload = yaml.safe_load(file_handle)
     try:
         configuration = ApplicationConfiguration.model_validate(configuration_payload)
-    except ValidationError as validation_error:
+    except pydantic.ValidationError as validation_error:
         raise ValueError(str(validation_error)) from validation_error
     marker_names = read_marker_names(configuration.input_paths.markers)
     return configuration.validate_marker_names(marker_names)

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import logging
+import zlib
+from dataclasses import asdict
+from pathlib import Path
+
+import polars as pl
+import tifffile
+import yaml
+
+from src.annotation import annotate_cells
+from src.configuration import ApplicationConfiguration
+from src.data_models import RegionOfInterestBox
+from src.io import (
+    build_marker_name_to_index,
+    ensure_directory,
+    load_slide_metadata,
+    read_histology_region_of_interest,
+    read_readouts_region_of_interest,
+    save_cell_assignment_map,
+    save_preprocessing_comparison,
+    save_segmentation_overlay_image,
+    write_csv,
+    write_image_stack,
+    write_label_image,
+    write_yaml_file,
+)
+from src.preprocessing import preprocess_region_of_interest_patch
+from src.quantification import quantify_cells_in_region_of_interest
+from src.region_of_interest import choose_region_of_interest
+from src.segmentation import segment_cells_from_marker_images
+from src.spatial_analysis import compute_spatial_analysis
+
+STAGES = [
+    "select-roi",
+    "preprocess",
+    "segment",
+    "quantify",
+    "annotate",
+    "spatial",
+]
+
+
+def run_patch_pipeline(
+    configuration: ApplicationConfiguration,
+    logger: logging.Logger,
+    stage: str | None = None,
+) -> None:
+    """Execute all pipeline stages in order, or a single stage if specified."""
+    if stage is not None:
+        _STAGE_FUNCTIONS[stage](configuration, logger)
+    else:
+        for stage_name in STAGES:
+            _STAGE_FUNCTIONS[stage_name](configuration, logger)
+
+    write_yaml_file(
+        configuration.sample_output_directory / "configuration_snapshot.yaml",
+        configuration.model_dump(mode="json"),
+    )
+
+    logger.info("pipeline_output_directory: %s", configuration.sample_output_directory)
+
+
+def run_select_roi(
+    configuration: ApplicationConfiguration,
+    logger: logging.Logger,
+) -> None:
+    """Select the best patch from the slide and write the raw patch and ROI metadata."""
+    output_directory = ensure_directory(configuration.sample_output_directory)
+    slide_metadata = load_slide_metadata(configuration)
+
+    logger.info("mode: %s", "patch")
+    logger.info("sample_identifier: %s", configuration.sample_identifier)
+    logger.info("readouts: %s", configuration.input_paths.readouts)
+    logger.info("marker_count: %s", len(slide_metadata.marker_names))
+    logger.info("image_width_pixels: %s", slide_metadata.width_pixels)
+    logger.info("image_height_pixels: %s", slide_metadata.height_pixels)
+    logger.info("pixel_size_x_micrometers: %s", slide_metadata.pixel_size_x_micrometers)
+    logger.info("pixel_size_y_micrometers: %s", slide_metadata.pixel_size_y_micrometers)
+
+    selected_roi, candidate_data_frame = choose_region_of_interest(
+        configuration, slide_metadata
+    )
+    selected_candidate = candidate_data_frame.filter(pl.col("selected")).to_dicts()
+    if selected_candidate:
+        logger.info("region_of_interest_quality: %s", selected_candidate[0])
+
+    raw_patch = read_readouts_region_of_interest(
+        configuration.input_paths.readouts, selected_roi
+    )
+    write_image_stack(
+        output_directory / "raw_patch.tif",
+        raw_patch,
+        slide_metadata.marker_names,
+    )
+
+    if configuration.input_paths.histology:
+        histology_patch = read_histology_region_of_interest(
+            configuration.input_paths.histology, selected_roi
+        )
+        tifffile.imwrite(
+            output_directory / "histology_patch.tif",
+            histology_patch,
+        )
+
+    write_yaml_file(
+        output_directory / "roi_metadata.yaml",
+        {
+            **asdict(selected_roi),
+            "pixel_size_x_micrometers": slide_metadata.pixel_size_x_micrometers,
+            "pixel_size_y_micrometers": slide_metadata.pixel_size_y_micrometers,
+            "marker_names": slide_metadata.marker_names,
+        },
+    )
+
+    logger.info("selected_region_of_interest: %s", asdict(selected_roi))
+
+
+def run_preprocess(
+    configuration: ApplicationConfiguration,
+    logger: logging.Logger,
+) -> None:
+    """Subtract autofluorescence from the raw patch and save the corrected stack."""
+    output_directory = configuration.sample_output_directory
+    roi_metadata = _load_roi_metadata(output_directory)
+    marker_names = roi_metadata["marker_names"]
+
+    raw_patch = tifffile.imread(output_directory / "raw_patch.tif")
+
+    random_seed = zlib.crc32(configuration.sample_identifier.encode("utf-8"))
+    preprocessing_result = preprocess_region_of_interest_patch(
+        raw_patch,
+        marker_names,
+        configuration,
+        random_seed,
+    )
+
+    write_image_stack(
+        output_directory / "corrected_patch.tif",
+        preprocessing_result.corrected_image_stack,
+        marker_names,
+    )
+
+    marker_name_to_index = build_marker_name_to_index(marker_names)
+    comparison_index = marker_name_to_index[configuration.channels.cytoplasmic_marker]
+    save_preprocessing_comparison(
+        raw_patch[comparison_index],
+        preprocessing_result.corrected_image_stack[comparison_index],
+        configuration.channels.cytoplasmic_marker,
+        output_directory / "preprocessing_comparison.png",
+    )
+
+    logger.info("preprocessing complete")
+
+
+def run_segment(
+    configuration: ApplicationConfiguration,
+    logger: logging.Logger,
+) -> None:
+    """Segment cells from the corrected patch and write the label mask and overlay."""
+    output_directory = configuration.sample_output_directory
+    roi_metadata = _load_roi_metadata(output_directory)
+    marker_name_to_index = build_marker_name_to_index(roi_metadata["marker_names"])
+
+    corrected_patch = tifffile.imread(output_directory / "corrected_patch.tif")
+    nuclear_index = marker_name_to_index[configuration.channels.nuclear_marker]
+    cytoplasmic_index = marker_name_to_index[configuration.channels.cytoplasmic_marker]
+
+    segmentation_result = segment_cells_from_marker_images(
+        corrected_patch[nuclear_index],
+        corrected_patch[cytoplasmic_index],
+        configuration,
+    )
+
+    write_label_image(
+        output_directory / "segmentation_mask.tif",
+        segmentation_result.cell_labels,
+    )
+
+    histology_path = output_directory / "histology_patch.tif"
+    background_image = (
+        tifffile.imread(histology_path)
+        if histology_path.exists()
+        else corrected_patch[cytoplasmic_index]
+    )
+    save_segmentation_overlay_image(
+        background_image,
+        segmentation_result.cell_labels,
+        output_directory / "segmentation_overlay.tif",
+    )
+
+    logger.info(
+        "segmentation complete: %d cells",
+        int(segmentation_result.cell_labels.max()),
+    )
+
+
+def run_quantify(
+    configuration: ApplicationConfiguration,
+    logger: logging.Logger,
+) -> None:
+    """Measure per-cell morphology and marker intensities and write cell_features.csv."""
+    output_directory = configuration.sample_output_directory
+    roi_metadata = _load_roi_metadata(output_directory)
+    marker_names = roi_metadata["marker_names"]
+    marker_name_to_index = build_marker_name_to_index(marker_names)
+
+    corrected_patch = tifffile.imread(output_directory / "corrected_patch.tif")
+    raw_patch = tifffile.imread(output_directory / "raw_patch.tif")
+    label_image = tifffile.imread(output_directory / "segmentation_mask.tif")
+
+    region_of_interest = RegionOfInterestBox(
+        x_pixels=roi_metadata["x_pixels"],
+        y_pixels=roi_metadata["y_pixels"],
+        width_pixels=roi_metadata["width_pixels"],
+        height_pixels=roi_metadata["height_pixels"],
+    )
+
+    intensity_image_by_marker = {
+        marker_name: (
+            raw_patch[marker_index].astype(float)
+            if marker_name == configuration.channels.autofluorescence_marker
+            else corrected_patch[marker_index].astype(float)
+        )
+        for marker_name, marker_index in marker_name_to_index.items()
+    }
+
+    cell_features = quantify_cells_in_region_of_interest(
+        label_image,
+        intensity_image_by_marker,
+        marker_names,
+        region_of_interest,
+        roi_metadata["pixel_size_x_micrometers"],
+        roi_metadata["pixel_size_y_micrometers"],
+    )
+
+    write_csv(
+        cell_features,
+        output_directory / "cell_features.csv",
+    )
+
+    logger.info("quantification complete: %d cells", cell_features.height)
+
+
+def run_annotate(
+    configuration: ApplicationConfiguration,
+    logger: logging.Logger,
+) -> None:
+    """Assign cell type labels from quantified features and save annotations and map."""
+    output_directory = configuration.sample_output_directory
+    cell_features = pl.read_csv(output_directory / "cell_features.csv")
+
+    cell_annotations = annotate_cells(
+        cell_features,
+        configuration,
+    )
+
+    write_csv(
+        cell_annotations,
+        output_directory / "cell_annotations.csv",
+    )
+
+    save_cell_assignment_map(
+        cell_annotations,
+        "cell_type",
+        "Cell type map",
+        output_directory / "cell_type_map.png",
+    )
+
+    logger.info("annotation complete")
+
+
+def run_spatial(
+    configuration: ApplicationConfiguration,
+    logger: logging.Logger,
+) -> None:
+    """Compute spatial neighborhoods, domains, and adjacency enrichment metrics."""
+    output_directory = configuration.sample_output_directory
+    cell_annotations = pl.read_csv(output_directory / "cell_annotations.csv")
+
+    if "spatial_domain" in cell_annotations.columns:
+        cell_annotations = cell_annotations.drop("spatial_domain")
+
+    random_seed = zlib.crc32(configuration.sample_identifier.encode("utf-8"))
+    spatial_analysis_result = compute_spatial_analysis(
+        cell_annotations,
+        configuration,
+        random_seed,
+    )
+
+    write_csv(
+        spatial_analysis_result.cell_annotations_with_domains,
+        output_directory / "cell_annotations.csv",
+    )
+    write_csv(
+        spatial_analysis_result.spatial_metrics,
+        output_directory / "spatial_metrics.csv",
+    )
+
+    save_cell_assignment_map(
+        spatial_analysis_result.cell_annotations_with_domains,
+        "spatial_domain",
+        "Spatial domain map",
+        output_directory / "spatial_domain_map.png",
+    )
+
+    logger.info("spatial analysis complete")
+
+
+def _load_roi_metadata(output_directory: Path) -> dict:
+    """Load ROI metadata from the YAML file written by the select-roi stage."""
+    metadata_path = output_directory / "roi_metadata.yaml"
+    if not metadata_path.exists():
+        raise FileNotFoundError(
+            f"ROI metadata not found at {metadata_path}. "
+            "Run the select-roi stage first."
+        )
+    with metadata_path.open("r", encoding="utf-8") as file_handle:
+        return yaml.safe_load(file_handle)
+
+
+_STAGE_FUNCTIONS = {
+    "select-roi": run_select_roi,
+    "preprocess": run_preprocess,
+    "segment": run_segment,
+    "quantify": run_quantify,
+    "annotate": run_annotate,
+    "spatial": run_spatial,
+}

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -3,269 +3,41 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
-from scipy import ndimage as scipy_ndimage
-from skimage import feature, filters, measure, morphology, segmentation
+from cellpose.models import CellposeModel
+from skimage import segmentation
 
 from src.configuration import ApplicationConfiguration
-from src.data_models import SegmentationValidationSummary
-from src.io import percentile_normalize_image
 
 
 @dataclass(frozen=True)
 class SegmentationResult:
-    nuclei_labels: np.ndarray
-    expanded_cell_labels: np.ndarray
-    kept_cell_labels: np.ndarray
-    chosen_peak_minimum_distance_pixels: int
+    cell_labels: np.ndarray
 
 
 def segment_cells_from_marker_images(
     nuclear_image: np.ndarray,
     cytoplasmic_image: np.ndarray,
     configuration: ApplicationConfiguration,
-    target_cell_count: int | None = None,
 ) -> SegmentationResult:
-    normalized_nuclear_image = percentile_normalize_image(
-        nuclear_image,
-        configuration.preprocessing.percentile_clip.lower_quantile,
-        configuration.preprocessing.percentile_clip.upper_quantile,
+    """Segment cells using Cellpose cyto3 with nuclear and cytoplasmic channels."""
+    model = CellposeModel(
+        model_type="cyto3",
+        gpu=configuration.segmentation.use_gpu,
     )
-    normalized_cytoplasmic_image = percentile_normalize_image(
-        cytoplasmic_image,
-        configuration.preprocessing.percentile_clip.lower_quantile,
-        configuration.preprocessing.percentile_clip.upper_quantile,
+    image_stack = np.stack(
+        [cytoplasmic_image, nuclear_image],
+        axis=-1,
     )
-    smoothed_nuclear_image = filters.gaussian(
-        normalized_nuclear_image,
-        sigma=configuration.segmentation.gaussian_sigma,
+    labels, _, _ = model.eval(
+        image_stack,
+        diameter=configuration.segmentation.cell_diameter_pixels,
+        channels=[1, 2],
     )
-    otsu_threshold = filters.threshold_otsu(smoothed_nuclear_image)
-    binary_nuclear_mask = smoothed_nuclear_image > otsu_threshold
-    binary_nuclear_mask = morphology.remove_small_objects(
-        binary_nuclear_mask,
-        min_size=configuration.segmentation.minimum_nucleus_area_pixels,
-    )
-    binary_nuclear_mask = morphology.remove_small_holes(
-        binary_nuclear_mask,
-        area_threshold=64,
-    )
-    labeled_nuclear_mask = measure.label(binary_nuclear_mask)
-
-    peak_minimum_distance_candidates = [
-        configuration.segmentation.peak_minimum_distance_pixels
-    ]
-    if target_cell_count is not None:
-        peak_minimum_distance_candidates = list(
-            range(configuration.segmentation.peak_minimum_distance_pixels, 1, -1)
-        )
-    segmentation_candidates = [
-        _segment_binary_mask_with_peak_distance(
-            labeled_nuclear_mask=labeled_nuclear_mask,
-            normalized_cytoplasmic_image=normalized_cytoplasmic_image,
-            configuration=configuration,
-            peak_minimum_distance_pixels=peak_minimum_distance_pixels,
-        )
-        for peak_minimum_distance_pixels in peak_minimum_distance_candidates
-    ]
-    if target_cell_count is None:
-        return segmentation_candidates[0]
-    return min(
-        segmentation_candidates,
-        key=lambda segmentation_result: (
-            abs(int(segmentation_result.kept_cell_labels.max()) - target_cell_count),
-            abs(
-                segmentation_result.chosen_peak_minimum_distance_pixels
-                - configuration.segmentation.peak_minimum_distance_pixels
-            ),
-        ),
-    )
-
-
-def _segment_binary_mask_with_peak_distance(
-    labeled_nuclear_mask: np.ndarray,
-    normalized_cytoplasmic_image: np.ndarray,
-    configuration: ApplicationConfiguration,
-    peak_minimum_distance_pixels: int,
-) -> SegmentationResult:
-    distance_transform = scipy_ndimage.distance_transform_edt(labeled_nuclear_mask > 0)
-    local_maxima_coordinates = feature.peak_local_max(
-        distance_transform,
-        min_distance=peak_minimum_distance_pixels,
-        labels=labeled_nuclear_mask > 0,
-    )
-    watershed_markers = np.zeros_like(labeled_nuclear_mask, dtype=np.int32)
-    if len(local_maxima_coordinates) > 0:
-        watershed_markers[tuple(local_maxima_coordinates.T)] = np.arange(
-            1,
-            len(local_maxima_coordinates) + 1,
-            dtype=np.int32,
-        )
-    else:
-        watershed_markers = measure.label(labeled_nuclear_mask > 0)
-    watershed_labels = segmentation.watershed(
-        -distance_transform,
-        watershed_markers,
-        mask=labeled_nuclear_mask > 0,
-    )
-    watershed_labels = remove_large_segmentation_labels(
-        watershed_labels,
-        maximum_area=configuration.segmentation.maximum_nucleus_area_pixels,
-    )
-    cell_body_mask = build_cell_body_mask(
-        labeled_nuclear_mask > 0,
-        normalized_cytoplasmic_image,
-        configuration.segmentation.cell_expansion_distance_pixels,
-    )
-    expanded_cell_labels = segmentation.watershed(
-        -normalized_cytoplasmic_image,
-        watershed_labels,
-        mask=cell_body_mask,
-    )
-    if int(expanded_cell_labels.max()) == 0:
-        expanded_cell_labels = segmentation.expand_labels(
-            watershed_labels,
-            distance=configuration.segmentation.cell_expansion_distance_pixels,
-        )
-    expanded_cell_labels = remove_small_segmentation_labels(
-        expanded_cell_labels,
-        minimum_area=80,
-    )
-    boundary_touching_labels = find_labels_touching_boundary(expanded_cell_labels)
-    kept_cell_labels = expanded_cell_labels.copy()
-    if boundary_touching_labels:
-        boundary_touching_mask = np.isin(
-            kept_cell_labels,
-            np.fromiter(boundary_touching_labels, dtype=np.int32),
-        )
-        kept_cell_labels[boundary_touching_mask] = 0
-    kept_cell_labels = relabel_sequentially(kept_cell_labels)
-    return SegmentationResult(
-        nuclei_labels=relabel_sequentially(watershed_labels),
-        expanded_cell_labels=expanded_cell_labels,
-        kept_cell_labels=kept_cell_labels,
-        chosen_peak_minimum_distance_pixels=peak_minimum_distance_pixels,
-    )
-
-
-def build_cell_body_mask(
-    nuclear_mask: np.ndarray,
-    normalized_cytoplasmic_image: np.ndarray,
-    expansion_distance_pixels: int,
-) -> np.ndarray:
-    if np.allclose(normalized_cytoplasmic_image, normalized_cytoplasmic_image.flat[0]):
-        return morphology.binary_dilation(
-            nuclear_mask,
-            morphology.disk(expansion_distance_pixels),
-        )
-    cytoplasmic_threshold = filters.threshold_otsu(normalized_cytoplasmic_image)
-    cytoplasmic_mask = normalized_cytoplasmic_image > cytoplasmic_threshold
-    if not np.any(cytoplasmic_mask):
-        cytoplasmic_mask = nuclear_mask.copy()
-    expanded_nuclear_mask = morphology.binary_dilation(
-        nuclear_mask,
-        morphology.disk(expansion_distance_pixels),
-    )
-    return cytoplasmic_mask | expanded_nuclear_mask
-
-
-def remove_large_segmentation_labels(
-    labels: np.ndarray, maximum_area: int
-) -> np.ndarray:
-    output_labels = labels.copy()
-    for region_properties in measure.regionprops(labels):
-        if region_properties.area > maximum_area:
-            output_labels[labels == region_properties.label] = 0
-    return relabel_sequentially(output_labels)
-
-
-def remove_small_segmentation_labels(
-    labels: np.ndarray, minimum_area: int
-) -> np.ndarray:
-    output_labels = labels.copy()
-    for region_properties in measure.regionprops(labels):
-        if region_properties.area < minimum_area:
-            output_labels[labels == region_properties.label] = 0
-    return relabel_sequentially(output_labels)
-
-
-def find_labels_touching_boundary(labels: np.ndarray) -> set[int]:
-    boundary_labels = set(np.unique(labels[0, :])) | set(np.unique(labels[-1, :]))
-    boundary_labels |= set(np.unique(labels[:, 0])) | set(np.unique(labels[:, -1]))
-    boundary_labels.discard(0)
-    return boundary_labels
+    labels = relabel_sequentially(labels)
+    return SegmentationResult(cell_labels=labels)
 
 
 def relabel_sequentially(labels: np.ndarray) -> np.ndarray:
+    """Renumber labels to a contiguous 1..N sequence, preserving background as 0."""
     relabeled_labels, _, _ = segmentation.relabel_sequential(labels)
     return relabeled_labels.astype(np.int32)
-
-
-def summarize_segmentation_validation(
-    existing_labels: np.ndarray | None,
-    new_labels: np.ndarray,
-) -> SegmentationValidationSummary | None:
-    if existing_labels is None:
-        return None
-    relabeled_existing_labels = relabel_sequentially(existing_labels.astype(np.int32))
-    relabeled_new_labels = relabel_sequentially(new_labels.astype(np.int32))
-    existing_region_properties = measure.regionprops(relabeled_existing_labels)
-    new_region_properties = measure.regionprops(relabeled_new_labels)
-    existing_areas = np.array(
-        [region_properties.area for region_properties in existing_region_properties],
-        dtype=float,
-    )
-    new_areas = np.array(
-        [region_properties.area for region_properties in new_region_properties],
-        dtype=float,
-    )
-    centroid_density_overlap = compute_centroid_density_overlap(
-        existing_region_properties,
-        new_region_properties,
-        relabeled_existing_labels.shape,
-    )
-    return SegmentationValidationSummary(
-        existing_cell_count=int(relabeled_existing_labels.max()),
-        new_cell_count=int(relabeled_new_labels.max()),
-        existing_median_area_square_pixels=float(np.median(existing_areas))
-        if existing_areas.size
-        else 0.0,
-        new_median_area_square_pixels=float(np.median(new_areas))
-        if new_areas.size
-        else 0.0,
-        centroid_density_overlap=centroid_density_overlap,
-    )
-
-
-def compute_centroid_density_overlap(
-    existing_region_properties: list[measure._regionprops.RegionProperties],
-    new_region_properties: list[measure._regionprops.RegionProperties],
-    image_shape: tuple[int, int],
-) -> float:
-    y_bin_count = max(image_shape[0] // 128, 2)
-    x_bin_count = max(image_shape[1] // 128, 2)
-    existing_points = np.array(
-        [
-            region_properties.centroid
-            for region_properties in existing_region_properties
-        ],
-        dtype=float,
-    )
-    new_points = np.array(
-        [region_properties.centroid for region_properties in new_region_properties],
-        dtype=float,
-    )
-    if len(existing_points) == 0 or len(new_points) == 0:
-        return 0.0
-    existing_histogram, _, _ = np.histogram2d(
-        existing_points[:, 0],
-        existing_points[:, 1],
-        bins=(y_bin_count, x_bin_count),
-    )
-    new_histogram, _, _ = np.histogram2d(
-        new_points[:, 0],
-        new_points[:, 1],
-        bins=(y_bin_count, x_bin_count),
-    )
-    if np.std(existing_histogram) == 0 or np.std(new_histogram) == 0:
-        return 0.0
-    return float(np.corrcoef(existing_histogram.ravel(), new_histogram.ravel())[0, 1])

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -41,15 +41,11 @@ def base_configuration_dictionary(temporary_path: Path) -> dict[str, object]:
             "percentile_clip": {"lower_quantile": 0.005, "upper_quantile": 0.995},
         },
         "segmentation": {
-            "gaussian_sigma": 1.2,
-            "minimum_nucleus_area_pixels": 60,
-            "maximum_nucleus_area_pixels": 1500,
-            "peak_minimum_distance_pixels": 6,
-            "cell_expansion_distance_pixels": 6,
+            "cell_diameter_pixels": None,
+            "use_gpu": False,
         },
         "normalization": {
             "arcsinh_cofactor": 150.0,
-            "threshold_method": "otsu_with_fallback",
             "positive_fraction_minimum": 0.005,
             "positive_fraction_maximum": 0.70,
             "fallback_quantile": 0.90,
@@ -61,8 +57,6 @@ def base_configuration_dictionary(temporary_path: Path) -> dict[str, object]:
         },
         "spatial_analysis": {
             "nearest_neighbor_count": 10,
-            "minimum_cells_per_type_for_pairwise_analysis": 25,
-            "minimum_cells_per_type_for_clustering": 50,
             "permutation_count": 10,
             "neighborhood_cluster_count": 3,
         },

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -1,46 +1,17 @@
-from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
-import polars as pl
-import pytest
-import tifffile
 
-from src.configuration import load_configuration
-from src.io import load_slide_metadata
-from src.preprocessing import preprocess_region_of_interest_patch
-from src.region_of_interest import choose_region_of_interest
-from src.segmentation import (
-    find_labels_touching_boundary,
-    segment_cells_from_marker_images,
-    summarize_segmentation_validation,
-)
-
-REAL_DATA_CONFIGURATION_PATH = Path(
-    "/Users/rohit/Desktop/orion/configurations/CRC33_01.yaml"
-)
-REAL_DATA_SEGMENTATION_PATH = Path(
-    "/Users/rohit/Desktop/orion/data/CRC33_01/segmentation.tif"
-)
-REAL_DATA_QUANTIFICATIONS_PATH = Path(
-    "/Users/rohit/Desktop/orion/data/CRC33_01/quantifications.csv"
-)
+from src.segmentation import segment_cells_from_marker_images
 
 
 class DummySegmentationConfiguration:
-    gaussian_sigma = 1.2
-    minimum_nucleus_area_pixels = 10
-    maximum_nucleus_area_pixels = 800
-    peak_minimum_distance_pixels = 4
-    cell_expansion_distance_pixels = 4
-
-
-class DummyPercentileClipConfiguration:
-    lower_quantile = 0.005
-    upper_quantile = 0.995
+    cell_diameter_pixels = 30.0
+    use_gpu = False
 
 
 class DummyPreprocessingConfiguration:
-    percentile_clip = DummyPercentileClipConfiguration()
+    pass
 
 
 class DummyApplicationConfiguration:
@@ -48,122 +19,61 @@ class DummyApplicationConfiguration:
     preprocessing = DummyPreprocessingConfiguration()
 
 
-def test_watershed_splits_touching_nuclei() -> None:
-    nuclear_image = np.zeros((64, 64), dtype=np.float32)
-    cytoplasmic_image = np.zeros((64, 64), dtype=np.float32)
-    row_coordinates, column_coordinates = np.ogrid[:64, :64]
-    nuclear_image[
-        (row_coordinates - 24) ** 2 + (column_coordinates - 24) ** 2 < 100
-    ] = 1.0
-    nuclear_image[
-        (row_coordinates - 24) ** 2 + (column_coordinates - 38) ** 2 < 100
-    ] = 1.0
-    cytoplasmic_image[
-        (row_coordinates - 24) ** 2 + (column_coordinates - 24) ** 2 < 196
-    ] = 1.0
-    cytoplasmic_image[
-        (row_coordinates - 24) ** 2 + (column_coordinates - 38) ** 2 < 196
-    ] = 1.0
-    segmentation_result = segment_cells_from_marker_images(
-        nuclear_image,
-        cytoplasmic_image,
+@patch("src.segmentation.CellposeModel")
+def test_cellpose_returns_sequential_int32_labels(
+    mock_cellpose_class: MagicMock,
+) -> None:
+    mock_model = MagicMock()
+    mock_cellpose_class.return_value = mock_model
+    mock_labels = np.array(
+        [[0, 0, 5, 5], [0, 0, 5, 5], [3, 3, 0, 0], [3, 3, 0, 0]],
+        dtype=np.int32,
+    )
+    mock_model.eval.return_value = (mock_labels, None, None)
+
+    result = segment_cells_from_marker_images(
+        np.zeros((4, 4), dtype=np.float32),
+        np.zeros((4, 4), dtype=np.float32),
         DummyApplicationConfiguration(),
     )
-    assert segmentation_result.nuclei_labels.max() >= 2
+
+    assert result.cell_labels.dtype == np.int32
+    unique_labels = set(np.unique(result.cell_labels)) - {0}
+    assert unique_labels == {1, 2}
 
 
-def test_expanded_labels_do_not_overlap() -> None:
-    nuclear_image = np.zeros((64, 64), dtype=np.float32)
-    cytoplasmic_image = np.zeros((64, 64), dtype=np.float32)
-    nuclear_image[16:24, 16:24] = 1
-    nuclear_image[40:48, 40:48] = 1
-    cytoplasmic_image[12:28, 12:28] = 1
-    cytoplasmic_image[36:52, 36:52] = 1
-    segmentation_result = segment_cells_from_marker_images(
-        nuclear_image,
-        cytoplasmic_image,
+@patch("src.segmentation.CellposeModel")
+def test_cellpose_called_with_correct_channels(mock_cellpose_class: MagicMock) -> None:
+    mock_model = MagicMock()
+    mock_cellpose_class.return_value = mock_model
+    mock_model.eval.return_value = (np.zeros((4, 4), dtype=np.int32), None, None)
+
+    segment_cells_from_marker_images(
+        np.zeros((4, 4), dtype=np.float32),
+        np.zeros((4, 4), dtype=np.float32),
         DummyApplicationConfiguration(),
     )
-    assert np.all(segmentation_result.expanded_cell_labels >= 0)
+
+    mock_model.eval.assert_called_once()
+    call_kwargs = mock_model.eval.call_args
+    assert call_kwargs.kwargs["channels"] == [1, 2]
 
 
-def test_boundary_touching_labels_detected() -> None:
-    label_image = np.zeros((8, 8), dtype=np.int32)
-    label_image[0:3, 0:3] = 1
-    label_image[4:6, 4:6] = 2
-    assert find_labels_touching_boundary(label_image) == {1}
+@patch("src.segmentation.CellposeModel")
+def test_cellpose_receives_diameter_and_gpu(mock_cellpose_class: MagicMock) -> None:
+    mock_model = MagicMock()
+    mock_cellpose_class.return_value = mock_model
+    mock_model.eval.return_value = (np.zeros((4, 4), dtype=np.int32), None, None)
 
+    segment_cells_from_marker_images(
+        np.zeros((4, 4), dtype=np.float32),
+        np.zeros((4, 4), dtype=np.float32),
+        DummyApplicationConfiguration(),
+    )
 
-@pytest.mark.skipif(
-    not REAL_DATA_CONFIGURATION_PATH.exists()
-    or not REAL_DATA_SEGMENTATION_PATH.exists()
-    or not REAL_DATA_QUANTIFICATIONS_PATH.exists(),
-    reason="Real CRC33_01 inputs are not available.",
-)
-def test_real_patch_segmentation_has_reasonable_overlap_with_reference() -> None:
-    configuration = load_configuration(REAL_DATA_CONFIGURATION_PATH)
-    slide_metadata = load_slide_metadata(configuration)
-    region_of_interest, _ = choose_region_of_interest(configuration, slide_metadata)
-    readout_patch = tifffile.imread(
-        configuration.input_paths.readouts,
-        selection=(
-            slice(None),
-            slice(region_of_interest.y_pixels, region_of_interest.y_end_pixels),
-            slice(region_of_interest.x_pixels, region_of_interest.x_end_pixels),
-        ),
+    mock_cellpose_class.assert_called_once_with(
+        model_type="cyto3",
+        gpu=False,
     )
-    reference_segmentation_patch = tifffile.imread(
-        REAL_DATA_SEGMENTATION_PATH,
-        selection=(
-            slice(region_of_interest.y_pixels, region_of_interest.y_end_pixels),
-            slice(region_of_interest.x_pixels, region_of_interest.x_end_pixels),
-        ),
-    )
-    preprocessing_result = preprocess_region_of_interest_patch(
-        readout_patch,
-        slide_metadata.marker_names,
-        configuration,
-    )
-    marker_name_to_index = {
-        marker_name: index
-        for index, marker_name in enumerate(slide_metadata.marker_names)
-    }
-    segmentation_result = segment_cells_from_marker_images(
-        preprocessing_result.corrected_image_stack[
-            marker_name_to_index[configuration.channels.nuclear_marker]
-        ],
-        preprocessing_result.corrected_image_stack[
-            marker_name_to_index[configuration.channels.cytoplasmic_marker]
-        ],
-        configuration,
-    )
-    validation_summary = summarize_segmentation_validation(
-        reference_segmentation_patch,
-        segmentation_result.kept_cell_labels,
-    )
-    assert validation_summary is not None
-    assert validation_summary.new_cell_count > 0
-    assert validation_summary.existing_cell_count > 0
-    reference_quantification_count = int(
-        pl.scan_csv(REAL_DATA_QUANTIFICATIONS_PATH)
-        .filter(
-            (pl.col("X_centroid") >= region_of_interest.x_pixels)
-            & (pl.col("X_centroid") < region_of_interest.x_end_pixels)
-            & (pl.col("Y_centroid") >= region_of_interest.y_pixels)
-            & (pl.col("Y_centroid") < region_of_interest.y_end_pixels)
-        )
-        .select(pl.len())
-        .collect()
-        .item()
-    )
-    relative_cell_count_delta = (
-        abs(validation_summary.new_cell_count - validation_summary.existing_cell_count)
-        / validation_summary.existing_cell_count
-    )
-    relative_quantification_delta = abs(
-        validation_summary.new_cell_count - reference_quantification_count
-    ) / max(reference_quantification_count, 1)
-    assert relative_cell_count_delta < 0.75
-    assert reference_quantification_count > 0
-    assert relative_quantification_delta < 0.75
-    assert validation_summary.centroid_density_overlap > 0.0
+    call_kwargs = mock_model.eval.call_args
+    assert call_kwargs.kwargs["diameter"] == 30.0

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,30 @@ wheels = [
 ]
 
 [[package]]
+name = "cellpose"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastremap" },
+    { name = "fill-voids" },
+    { name = "imagecodecs" },
+    { name = "natsort" },
+    { name = "numpy" },
+    { name = "opencv-python-headless" },
+    { name = "roifile" },
+    { name = "scipy" },
+    { name = "segment-anything" },
+    { name = "tifffile" },
+    { name = "torch" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/b0/3dde4f82033a4b8e35a48d7419aa9c4f3e7c1100055a135790a41c47f19b/cellpose-4.1.1.tar.gz", hash = "sha256:859c732c8edede78ec7ee6537c5cfb18ab54f3dc01846adc10edca0cec124094", size = 4252891, upload-time = "2026-03-31T16:40:23.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/33/c2fbe5d074e2bb95bacdada02ebfa05915d211b67ab590419be1449d2115/cellpose-4.1.1-py3-none-any.whl", hash = "sha256:52d33d3c890df5572bec029ec4211388611b313c58f7b7073f47622b9befc32a", size = 213394, upload-time = "2026-03-31T16:40:21.147Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -157,6 +181,73 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5e/c0fe77a73aaefd3fff25ffaccaac69c5a63eafdf8b9a4c476626ef0ac703/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626", size = 6191386, upload-time = "2026-03-11T00:12:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/58/ed2c3b39c8dd5f96aa7a4abef0d47a73932c7a988e30f5fa428f00ed0da1/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771", size = 5507469, upload-time = "2026-03-11T00:13:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/0c941b112ceeb21439b05895eace78ca1aa2eaaf695c8521a068fd9b4c00/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b", size = 6059693, upload-time = "2026-03-11T00:13:06.003Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/f9/1b9b60a30fc463c14cdea7a77228131a0ccc89572e8df9cb86c9648271ab/cuda_pathfinder-1.5.2-py3-none-any.whl", hash = "sha256:0c5f160a7756c5b072723cbbd6d861e38917ef956c68150b02f0b6e9271c71fa", size = 49988, upload-time = "2026-04-06T23:01:05.17Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -222,12 +313,57 @@ wheels = [
 ]
 
 [[package]]
+name = "fastremap"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/b5/c33627109b34520315593c7415cb4e81125114082be07bd4c4e507ab6e17/fastremap-1.18.0.tar.gz", hash = "sha256:8e46acf8ffc7e9733852cc68659b0776ab951bb7e584c6df4f2c14f7bcebea5f", size = 50725, upload-time = "2026-03-17T18:52:28.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/93/10fac690bd697fe1398435bd59dfef98a58b7c852b6768ed5d0b9bde6681/fastremap-1.18.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1c55207cd905adeaf7a24c38d49afde28b16dd3846a60508b5593f11bb7ef9f9", size = 679327, upload-time = "2026-03-17T18:52:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/53/46ecb06e02d23e03480d81b24609e1c38ba15eda630c67fdbda62ad5902e/fastremap-1.18.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1b793657d1b7215f5d806c3f92df18d0a1b2de3dc659ec462a0933ed2f862107", size = 564713, upload-time = "2026-03-17T18:52:01.525Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/5c/b7935dccd06916a1fb5bd8bc4e5ac92f89659307b838abb18b8d632410f5/fastremap-1.18.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:38fb274f9ad29cca5b72f4dedb92a196591657ac239e9b29c9951121d1f8862c", size = 6734169, upload-time = "2026-03-17T18:52:03.704Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0b/49e8afc40de774a373d1404c6103784ea40f6873e163a4c08e426112547b/fastremap-1.18.0-cp313-cp313-win32.whl", hash = "sha256:82717feb7426e2b413b27fad10b22c4c744a4e0f6acb50969338848bb0846f4d", size = 415925, upload-time = "2026-03-17T18:52:06.556Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/c1/19b4a311cf74388a109bf400cb905a81db8a245a8abd8b2aa80de542ff5e/fastremap-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:c7f4b442f634942b1fbd6cc820e90cbb70b0f0ba2356ef488378dcbc11f7233e", size = 578688, upload-time = "2026-03-17T18:52:05.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/51/eee7af4696e848cb589f06b7bf2af573cd22bf7d29969ba4c3fe933614d1/fastremap-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:534c2148f5853d25e68a5470590aba0d76e9d11b4b34d436b4884db7971c4a86", size = 678321, upload-time = "2026-03-17T18:52:07.858Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/42/5459e5913dda9ec805b695f42b9d9ee91391a66560f83ca8758cd875b32f/fastremap-1.18.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0623ea36e9465d4fcd6ba82380372242b06d4c23f31a1192d7f2fd2420c615e", size = 573517, upload-time = "2026-03-17T18:52:08.919Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/83/4235a25c069d2fb7775d0e8cb0ecba3654f68dce6f0678301bf5eba0e573/fastremap-1.18.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a528d87f2d8aa4a3dcf3b66b96570706d44e896c202e241e8e31298621b90bbb", size = 6640855, upload-time = "2026-03-17T18:52:11.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/8b/17090e4fca0b146a640924a6ba680db7534c0db9bf28fb67ddf2d1d3902a/fastremap-1.18.0-cp314-cp314-win32.whl", hash = "sha256:17f99a67dc63fc086f16ff6371dcf8748be3703995fcc047e9452eb5fcca54d9", size = 422083, upload-time = "2026-03-17T18:52:13.696Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d8/f59b750f705f9da030239115d62eb620e7d64eb83100cbecb0ff4c35fc5e/fastremap-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:9b120390a80d39ac97c72d62c928b7098ac48960c4e782fe26b153747990c88f", size = 591199, upload-time = "2026-03-17T18:52:12.457Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c6/01954f9798eaf3fbc24781ed96d5e4e750228764ecc3369aa36a84d8278f/fastremap-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:34ca03930e01fa8811300e2964ad7f97aff3bf11f57be3fbe5915714b9b856cb", size = 730524, upload-time = "2026-03-17T18:52:14.706Z" },
+    { url = "https://files.pythonhosted.org/packages/66/64/1282cb3dca1ed4209d18d3b64971b7beb5b99dff7d21166098cb766e9c85/fastremap-1.18.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c65418660acdd8bd1f522a7bdd72c2bfb834ef9c754de1fa23989fdfc1cf2a7b", size = 627714, upload-time = "2026-03-17T18:52:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d0/267b721686690ce854495a4625bf76ea2ef78b6ccd115038ffd87ddeafa9/fastremap-1.18.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f427bc6731d4b32fb8fb032fa593fd815a049493db366ec9a346a94939d06eb", size = 6514147, upload-time = "2026-03-17T18:52:18.209Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ec/5a14de31d04780c2804d8a629a8ce94e705b475799c9eb3b0e02ca59675d/fastremap-1.18.0-cp314-cp314t-win32.whl", hash = "sha256:87dcaccd0760ec12052ab6962c5783657fd7cd6e1c8cc78efca7bf657a3b18cd", size = 530743, upload-time = "2026-03-17T18:52:20.626Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c5/94b15a4dff7343a0f052b54b2e2e9a105d9b3719b51cf8e58fdeda06098b/fastremap-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8865b25d157f174d2c17c824dd07bf5017de5824cb26706a2603ead66d95f292", size = 739811, upload-time = "2026-03-17T18:52:19.588Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.24.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/02/a8/dae62680be63cbb3ff87cfa2f51cf766269514ea5488479d42fec5aa6f3a/filelock-3.24.2.tar.gz", hash = "sha256:c22803117490f156e59fafce621f0550a7a853e2bbf4f87f112b11d469b6c81b", size = 37601, upload-time = "2026-02-16T02:50:45.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/04/a94ebfb4eaaa08db56725a40de2887e95de4e8641b9e902c311bfa00aa39/filelock-3.24.2-py3-none-any.whl", hash = "sha256:667d7dc0b7d1e1064dd5f8f8e80bdac157a6482e8d2e02cd16fd3b6b33bd6556", size = 24152, upload-time = "2026-02-16T02:50:44Z" },
+]
+
+[[package]]
+name = "fill-voids"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastremap" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/11/6dff4280502b81e92a69442d6d82a343610192ccbc2638ab921ffc273505/fill_voids-2.1.1.tar.gz", hash = "sha256:469f543e4ab236cf11aacef106af8e73c730f2a90f1bfae760dc8de29d4d6634", size = 3229026, upload-time = "2025-09-03T05:28:32.579Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/33/9e88a57eb5a8db4af3e0c0627899ad27d15f9f302346af080cbe08c4461f/fill_voids-2.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cc0db7f6c8d104fc06095881aaee574a3ec41253305331584e517063b58a2fde", size = 220109, upload-time = "2025-09-03T05:28:13.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/e7/a6e906a66622708ab40c290709934fa316ca09811da265697b86b0c75155/fill_voids-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f6ffc9df8dd8454e8546ea8255a3aef8be14e6750133f80e4488942e5184f554", size = 201165, upload-time = "2025-09-03T05:28:15.248Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/a4/2d0576917aed75cee755a13352b3673dfac5e1329eca9bdcbf063881acd2/fill_voids-2.1.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96132967d7cf392804b7bdaa298643271ff738baa4355e5791c2e0b28f861e74", size = 1511403, upload-time = "2025-09-03T12:19:28.15Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ed/eb4690aab1158008f3f79d53001990972cd56033f062c429a9a92ead55e8/fill_voids-2.1.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2da7adb953fd35ba9757d78f95c3ecd3fc6e762e5ae35ccdd69c0562b5ce2cd4", size = 1543020, upload-time = "2025-09-03T05:28:16.862Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/36/1b8da040a18116c95fb732dec0282d502839953cd4affa89636a261abad4/fill_voids-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4edf017a09c89b8ea1dc386cf1078b6ea4757dcdadafc0874cd4b4e88c592e95", size = 2341684, upload-time = "2025-09-03T12:19:29.605Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/36/9b587d192ad130ade9bb53ef3dcda3d4bd60774ef4921ad9062bc9263300/fill_voids-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:482be2391309afa8bee93a6e8ba07bfed453a730fe557c2c0a99a620aba7bb4e", size = 2420380, upload-time = "2025-09-03T05:28:18.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/24/f4ed44e103ee7ec9880c43bb06a9d60eab5f06d80022f83005c67304655d/fill_voids-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:976f6a3c5a68f3f3483da779d8c71f11e8e3eec4c104d0d594ba5cd11a36a7fa", size = 181694, upload-time = "2025-09-03T05:28:19.728Z" },
 ]
 
 [[package]]
@@ -261,6 +397,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/40/cc11f378b561a67bea850ab50063366a0d1dd3f6d0a30ce0f874b0ad5664/fonttools-4.61.1-cp314-cp314t-win32.whl", hash = "sha256:aed04cabe26f30c1647ef0e8fbb207516fd40fe9472e9439695f5c6998e60ac5", size = 2335377, upload-time = "2025-12-12T17:31:16.49Z" },
     { url = "https://files.pythonhosted.org/packages/e4/ff/c9a2b66b39f8628531ea58b320d66d951267c98c6a38684daa8f50fb02f8/fonttools-4.61.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2180f14c141d2f0f3da43f3a81bc8aa4684860f6b0e6f9e165a4831f24e6a23b", size = 2400613, upload-time = "2025-12-12T17:31:18.769Z" },
     { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", size = 1148996, upload-time = "2025-12-12T17:31:21.03Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
 ]
 
 [[package]]
@@ -407,6 +552,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -516,6 +673,58 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "matplotlib"
 version = "3.10.8"
 source = { registry = "https://pypi.org/simple" }
@@ -572,6 +781,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
 ]
 
 [[package]]
@@ -674,10 +901,178 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas"
+version = "13.1.0.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/42/2310883be3b8826ac58c3f2787b9358a2d46923d61f88fedf930bc59c60c/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:1a7d040ac656c11b8c38677cc8cccdc149f98535089dbe5b081e80a4e5903209", size = 46247192, upload-time = "2026-02-05T07:01:35.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/1e/6f9e38005a6f7f22af785df42a43139d0e20f169eb5787ce8be37ee7fcc9/opencv_python_headless-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:3e0a6f0a37994ec6ce5f59e936be21d5d6384a4556f2d2da9c2f9c5dc948394c", size = 32568914, upload-time = "2026-02-05T07:01:51.989Z" },
+    { url = "https://files.pythonhosted.org/packages/21/76/9417a6aef9def70e467a5bf560579f816148a4c658b7d525581b356eda9e/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c8cfc8e87ed452b5cecb9419473ee5560a989859fe1d10d1ce11ae87b09a2cb", size = 33703709, upload-time = "2026-02-05T10:24:46.469Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ce/bd17ff5772938267fd49716e94ca24f616ff4cb1ff4c6be13085108037be/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0525a3d2c0b46c611e2130b5fdebc94cf404845d8fa64d2f3a3b679572a5bd22", size = 56016764, upload-time = "2026-02-05T10:26:48.904Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b4/b7bcbf7c874665825a8c8e1097e93ea25d1f1d210a3e20d4451d01da30aa/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:eb60e36b237b1ebd40a912da5384b348df8ed534f6f644d8e0b4f103e272ba7d", size = 35010236, upload-time = "2026-02-05T10:28:11.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/33/b5db29a6c00eb8f50708110d8d453747ca125c8b805bc437b289dbdcc057/opencv_python_headless-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0bd48544f77c68b2941392fcdf9bcd2b9cdf00e98cb8c29b2455d194763cf99e", size = 60391106, upload-time = "2026-02-05T10:30:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c3/52cfea47cd33e53e8c0fbd6e7c800b457245c1fda7d61660b4ffe9596a7f/opencv_python_headless-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:a7cf08e5b191f4ebb530791acc0825a7986e0d0dee2a3c491184bd8599848a4b", size = 30812232, upload-time = "2026-02-05T07:02:29.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/90/b338326131ccb2aaa3c2c85d00f41822c0050139a4bfe723cfd95455bd2d/opencv_python_headless-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:77a82fe35ddcec0f62c15f2ba8a12ecc2ed4207c17b0902c7a3151ae29f37fb6", size = 40070414, upload-time = "2026-02-05T07:02:26.448Z" },
+]
+
+[[package]]
 name = "orion"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "cellpose" },
     { name = "imagecodecs" },
     { name = "matplotlib" },
     { name = "numpy" },
@@ -701,6 +1096,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cellpose", specifier = ">=4.1.1" },
     { name = "imagecodecs", specifier = ">=2026.1.14" },
     { name = "matplotlib", specifier = ">=3.10.8" },
     { name = "numpy", specifier = ">=2.2.2" },
@@ -1146,6 +1542,18 @@ wheels = [
 ]
 
 [[package]]
+name = "roifile"
+version = "2026.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/cf/49d9a139e292415d669dccd0c283d99a4d027b9edbd533d7f56db8ff85e0/roifile-2026.2.10.tar.gz", hash = "sha256:87d2b685b00a4ca15125187727e634ae5c00b902362de302b592f892259f3751", size = 27311, upload-time = "2026-02-11T19:54:35.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/78/3cc84d58e13234861adf91d2897254cd84d3d4a90534d91c960b672e67d1/roifile-2026.2.10-py3-none-any.whl", hash = "sha256:5928a616b58a8ff1c9f89a0590db3616ccbf069c6692f8ecec2a7349f8bbb6ec", size = 21201, upload-time = "2026-02-11T19:54:34.137Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1310,6 +1718,24 @@ wheels = [
 ]
 
 [[package]]
+name = "segment-anything"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/88/7725f418f2bb4a7ac2e5e8295fbbca2900c70c8fe5ba48b3aff5788af9a2/segment_anything-1.0.tar.gz", hash = "sha256:ed0c9f6fb07bbef9c6238a7028a13c8272f1ba6b6305ca73e3e064266503736b", size = 31191, upload-time = "2023-04-06T18:04:40.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/77/8e0c16abf151a1dd076b562febc0da2ecf1132b0b41826087af96f101f42/segment_anything-1.0-py3-none-any.whl", hash = "sha256:86f67d417a915823c3302098effe9008b688945772517310956bb49de0e7f02e", size = 36560, upload-time = "2023-04-06T18:04:38.834Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "81.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1330,6 +1756,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -1354,6 +1792,73 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/86/7cd7c66cb9cec6be330fff36db5bd0eef386d80c031b581ec81be1d4b26c/torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7", size = 419749385, upload-time = "2026-03-23T18:07:33.77Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/b98ca2d39b2e0e4730c0ee52537e488e7008025bc77ca89552ff91021f7c/torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60", size = 530716756, upload-time = "2026-03-23T18:07:50.02Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835, upload-time = "2026-03-23T18:07:18.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405, upload-time = "2026-03-23T18:08:07.014Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/80/0762f77f53605d10c9477be39bb47722cc8e383bbbc2531471ce0e396c07/torchvision-0.26.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5d63dd43162691258b1b3529b9041bac7d54caa37eae0925f997108268cbf7c4", size = 1860809, upload-time = "2026-03-23T18:12:47.629Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/81/0b3e58d1478c660a5af4268713486b2df7203f35abd9195fea87348a5178/torchvision-0.26.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a39c7a26538c41fda453f9a9692b5ff9b35a5437db1d94f3027f6f509c160eac", size = 7727494, upload-time = "2026-03-23T18:12:46.062Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/dc/d9ab5d29115aa05e12e30f1397a3eeae1d88a511241dc3bce48dc4342675/torchvision-0.26.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b7e6213620bbf97742e5f79832f9e9d769e6cf0f744c5b53dad80b76db633691", size = 7521747, upload-time = "2026-03-23T18:12:36.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/1b/f1bc86a918c5f6feab1eeff11982e2060f4704332e96185463d27855bdf5/torchvision-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:4280c35ec8cba1fcc8294fb87e136924708726864c379e4c54494797d86bc474", size = 4319880, upload-time = "2026-03-23T18:12:38.168Z" },
+    { url = "https://files.pythonhosted.org/packages/66/28/b4ad0a723ed95b003454caffcc41894b34bd8379df340848cae2c33871de/torchvision-0.26.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:358fc4726d0c08615b6d83b3149854f11efb2a564ed1acb6fce882e151412d23", size = 1951973, upload-time = "2026-03-23T18:12:48.781Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/7a89096e6cf2f3336353b5338ba925e0addf9d8601920340e6bdf47e8eb3/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:3daf9cc149cf3cdcbd4df9c59dae69ffca86c6823250442c3bbfd63fc2e26c61", size = 7728679, upload-time = "2026-03-23T18:12:26.196Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1d/4e1eebc17d18ce080a11dcf3df3f8f717f0efdfa00983f06e8ba79259f61/torchvision-0.26.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:82c3965eca27e86a316e31e4c3e5a16d353e0bcbe0ef8efa2e66502c54493c4b", size = 7609138, upload-time = "2026-03-23T18:12:35.327Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a4/f1155e943ae5b32400d7000adc81c79bb0392b16ceb33bcf13e02e48cced/torchvision-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ebc043cc5a4f0bf22e7680806dbba37ffb19e70f6953bbb44ed1a90aeb5c9bea", size = 4248202, upload-time = "2026-03-23T18:12:41.423Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c8/9bffa9c7f7bdf95b2a0a2dc535c290b9f1cc580c3fb3033ab1246ffffdeb/torchvision-0.26.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:eb61804eb9dbe88c5a2a6c4da8dec1d80d2d0a6f18c999c524e32266cb1ebcd3", size = 1860813, upload-time = "2026-03-23T18:12:39.636Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ac/48f28ffd227991f2e14f4392dde7e8dc14352bb9428c1ef4a4bbf5f7ed85/torchvision-0.26.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9a904f2131cbfadab4df828088a9f66291ad33f49ff853872aed1f86848ef776", size = 7727777, upload-time = "2026-03-23T18:12:22.549Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/21/a2266f7f1b0e58e624ff15fd6f01041f59182c49551ece0db9a183071329/torchvision-0.26.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0f3e572efe62ad645017ea847e0b5e4f2f638d4e39f05bc011d1eb9ac68d4806", size = 7522174, upload-time = "2026-03-23T18:12:29.565Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ba/1666f90bc0bdd77aaa11dcc42bb9f621a9c3668819c32430452e3d404730/torchvision-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:114bec0c0e98aa4ba446f63e2fe7a2cbca37b39ac933987ee4804f65de121800", size = 4348469, upload-time = "2026-03-23T18:12:24.44Z" },
+    { url = "https://files.pythonhosted.org/packages/45/8f/1f0402ac55c2ae15651ff831957d083fe70b2d12282e72612a30ba601512/torchvision-0.26.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:b7d3e295624a28b3b1769228ce1345d94cf4d390dd31136766f76f2d20f718da", size = 1860826, upload-time = "2026-03-23T18:12:34.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6a/18a582fe3c5ee26f49b5c9fb21ad8016b4d1c06d10178894a58653946fda/torchvision-0.26.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7058c5878262937e876f20c25867b33724586aa4499e2853b2d52b99a5e51953", size = 7729089, upload-time = "2026-03-23T18:12:31.394Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/9b/f7e119b59499edc00c55c03adc9ec3bd96144d9b81c46852c431f9c64a9a/torchvision-0.26.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8008474855623c6ba52876589dc52df0aa66e518c25eca841445348e5f79844c", size = 7522704, upload-time = "2026-03-23T18:12:20.301Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/6a/09f3844c10643f6c0de5d95abc863420cfaf194c88c7dffd0ac523e2015f/torchvision-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e9d0e022c19a78552fb055d0414d47fecb4a649309b9968573daea160ba6869c", size = 4454275, upload-time = "2026-03-23T18:12:27.487Z" },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1371,12 +1876,39 @@ wheels = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replace the classical watershed segmentation pipeline with Cellpose's pre-trained `cyto3` deep learning model. This reduces configuration from five hand-tuned parameters to two (`cell_diameter_pixels`, `use_gpu`) and improves segmentation quality for multiplex IF images.

## Changes

- Rewrite `src/segmentation.py` to use `CellposeModel` with `cyto3` instead of watershed
- Slim `SegmentationResult` dataclass to a single `cell_labels` field, removing `nuclei_labels`, `expanded_cell_labels`, and `chosen_peak_minimum_distance_pixels`
- Replace `SegmentationConfiguration` fields with `cell_diameter_pixels` and `use_gpu`
- Remove all watershed-specific utilities: boundary removal, size filters, cell body mask expansion
- Update `pipeline.py` to reference `cell_labels` instead of `kept_cell_labels`
- Rewrite segmentation tests to mock `CellposeModel.eval`
- Add `cellpose` as a runtime dependency

## Testing

`uv run pytest` — 33 passed, 1 pre-existing failure unrelated to this change. Segmentation tests mock `CellposeModel.eval` and verify correct channel configuration, parameter forwarding, and sequential int32 label output.

## Closes

Closes #4