### PR TITLE
feat: priority-based cell typing with negative marker support

### DIFF
--- a/configurations/CRC33_01.yaml
+++ b/configurations/CRC33_01.yaml
@@ -40,20 +40,27 @@ normalization:
 
 annotation:
   cell_types:
+    - name: regulatory T cell
+      positive_markers: [CD3e, CD4, FOXP3]
+    - name: helper T cell
+      positive_markers: [CD3e, CD4]
+      negative_markers: [FOXP3]
+    - name: cytotoxic T cell
+      positive_markers: [CD3e, CD8a]
+    - name: T cell
+      positive_markers: [CD3e]
+    - name: M2 macrophage
+      positive_markers: [CD68, CD163]
+    - name: macrophage
+      positive_markers: [CD68]
+    - name: B cell
+      positive_markers: [CD20]
     - name: epithelial cell
       positive_markers: [Pan-CK]
     - name: endothelial cell
       positive_markers: [CD31]
     - name: stromal cell
       positive_markers: [SMA]
-    - name: B cell
-      positive_markers: [CD20]
-    - name: T cell
-      positive_markers: [CD3e]
-    - name: macrophage
-      positive_markers: [CD68]
-    - name: regulatory T cell
-      positive_markers: [CD4, FOXP3]
 
 spatial_analysis:
   nearest_neighbor_count: 10

--- a/src/annotation.py
+++ b/src/annotation.py
@@ -42,22 +42,21 @@ def annotate_cells(
 
     thresholded_rows = annotated_cell_measurements.to_dicts()
     annotation_rows: list[dict[str, object]] = []
-    marker_names_by_cell_type = {
-        cell_type_rule.name: list(cell_type_rule.positive_markers)
-        for cell_type_rule in configuration.annotation.cell_types
-    }
+    cell_type_rules = configuration.annotation.cell_types
     for thresholded_row in thresholded_rows:
-        matched_cell_type_names = [
-            cell_type_name
-            for cell_type_name, marker_names in marker_names_by_cell_type.items()
-            if all(
+        cell_type = "unassigned"
+        for rule in cell_type_rules:
+            positives_match = all(
                 bool(thresholded_row[f"{marker_name}_high"])
-                for marker_name in marker_names
+                for marker_name in rule.positive_markers
             )
-        ]
-        cell_type = (
-            matched_cell_type_names[0] if len(matched_cell_type_names) == 1 else "Other"
-        )
+            negatives_match = all(
+                not bool(thresholded_row[f"{marker_name}_high"])
+                for marker_name in rule.negative_markers
+            )
+            if positives_match and negatives_match:
+                cell_type = rule.name
+                break
         annotation_row = {
             "cell_identifier": thresholded_row["cell_identifier"],
             "x_micrometers": thresholded_row["x_micrometers"],

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -67,6 +67,7 @@ class SpatialAnalysisConfiguration(BaseModel):
 class CellTypeAnnotationRuleConfiguration(BaseModel):
     name: str
     positive_markers: list[str] = Field(min_length=1)
+    negative_markers: list[str] = Field(default_factory=list)
 
 
 class AnnotationConfiguration(BaseModel):
@@ -166,7 +167,9 @@ class ApplicationConfiguration(BaseModel):
         seen_marker_names: set[str] = set()
         ordered_marker_names: list[str] = []
         for cell_type_rule in self.annotation.cell_types:
-            for marker_name in cell_type_rule.positive_markers:
+            for marker_name in (
+                cell_type_rule.positive_markers + cell_type_rule.negative_markers
+            ):
                 if marker_name not in seen_marker_names:
                     ordered_marker_names.append(marker_name)
                     seen_marker_names.add(marker_name)

--- a/src/io.py
+++ b/src/io.py
@@ -256,27 +256,6 @@ def save_cell_assignment_map(
         s=6,
         alpha=0.8,
     )
-    for label in unique_labels:
-        label_rows = cell_annotations.filter(pl.col(label_column_name) == label)
-        if label_rows.is_empty():
-            continue
-        x_position = float(np.median(label_rows["x_micrometers"].to_numpy()))
-        y_position = float(np.median(label_rows["y_micrometers"].to_numpy()))
-        axis.text(
-            x_position,
-            y_position,
-            str(label),
-            fontsize=8,
-            ha="center",
-            va="center",
-            color="black",
-            bbox={
-                "facecolor": "white",
-                "alpha": 0.75,
-                "edgecolor": "none",
-                "pad": 1.5,
-            },
-        )
     axis.set_title(title)
     axis.set_xlabel("x (μm)")
     axis.set_ylabel("y (μm)")

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -102,21 +102,153 @@ def test_multi_marker_rule_requires_all_positive_markers() -> None:
         ),
         configuration,
     )
-    assert cell_annotations[0, "cell_type"] == "Other"
+    assert cell_annotations[0, "cell_type"] == "unassigned"
 
 
-def test_multiple_matches_collapse_to_other() -> None:
+def test_first_matching_rule_wins() -> None:
     configuration = build_configuration(
         [
-            {"name": "B_cell", "positive_markers": ["CD20"]},
-            {"name": "Plasma_like", "positive_markers": ["CD20"]},
+            {"name": "Treg", "positive_markers": ["CD3e", "CD4", "FOXP3"]},
+            {"name": "T_cell", "positive_markers": ["CD3e"]},
         ]
     )
     cell_annotations = annotate_cells(
-        build_cell_features(CD20=1000.0),
+        build_cell_features(CD3e=1000.0, CD4=1000.0, FOXP3=1000.0),
         configuration,
     )
-    assert cell_annotations[0, "cell_type"] == "Other"
+    assert cell_annotations[0, "cell_type"] == "Treg"
+
+
+def test_parent_rule_matches_when_subtype_does_not() -> None:
+    configuration = build_configuration(
+        [
+            {"name": "Treg", "positive_markers": ["CD3e", "CD4", "FOXP3"]},
+            {"name": "T_cell", "positive_markers": ["CD3e"]},
+        ]
+    )
+    cell_annotations = annotate_cells(
+        pl.DataFrame(
+            [
+                {
+                    "cell_identifier": 1,
+                    "x_micrometers": 1.0,
+                    "y_micrometers": 2.0,
+                    "CD3e": 1000.0,
+                    "CD4": 0.0,
+                    "FOXP3": 0.0,
+                },
+                {
+                    "cell_identifier": 2,
+                    "x_micrometers": 3.0,
+                    "y_micrometers": 4.0,
+                    "CD3e": 1000.0,
+                    "CD4": 1000.0,
+                    "FOXP3": 1000.0,
+                },
+            ]
+        ),
+        configuration,
+    )
+    assert cell_annotations[0, "cell_type"] == "T_cell"
+    assert cell_annotations[1, "cell_type"] == "Treg"
+
+
+def test_negative_markers_exclude_cell() -> None:
+    configuration = build_configuration(
+        [
+            {
+                "name": "helper_T",
+                "positive_markers": ["CD3e", "CD4"],
+                "negative_markers": ["FOXP3"],
+            },
+        ]
+    )
+    cell_annotations = annotate_cells(
+        build_cell_features(CD3e=1000.0, CD4=1000.0, FOXP3=1000.0),
+        configuration,
+    )
+    assert cell_annotations[0, "cell_type"] == "unassigned"
+
+
+def test_negative_marker_low_allows_match() -> None:
+    configuration = build_configuration(
+        [
+            {
+                "name": "helper_T",
+                "positive_markers": ["CD3e", "CD4"],
+                "negative_markers": ["FOXP3"],
+            },
+        ]
+    )
+    cell_annotations = annotate_cells(
+        pl.DataFrame(
+            [
+                {
+                    "cell_identifier": 1,
+                    "x_micrometers": 1.0,
+                    "y_micrometers": 2.0,
+                    "CD3e": 1000.0,
+                    "CD4": 1000.0,
+                    "FOXP3": 0.0,
+                },
+                {
+                    "cell_identifier": 2,
+                    "x_micrometers": 3.0,
+                    "y_micrometers": 4.0,
+                    "CD3e": 1000.0,
+                    "CD4": 1000.0,
+                    "FOXP3": 1000.0,
+                },
+            ]
+        ),
+        configuration,
+    )
+    assert cell_annotations[0, "cell_type"] == "helper_T"
+    assert cell_annotations[1, "cell_type"] == "unassigned"
+
+
+def test_no_rule_match_labels_unassigned() -> None:
+    configuration = build_configuration(
+        [{"name": "B_cell", "positive_markers": ["CD20"]}]
+    )
+    cell_annotations = annotate_cells(
+        pl.DataFrame(
+            [
+                {
+                    "cell_identifier": 1,
+                    "x_micrometers": 1.0,
+                    "y_micrometers": 2.0,
+                    "CD20": 0.0,
+                },
+                {
+                    "cell_identifier": 2,
+                    "x_micrometers": 3.0,
+                    "y_micrometers": 4.0,
+                    "CD20": 1000.0,
+                },
+            ]
+        ),
+        configuration,
+    )
+    assert cell_annotations[0, "cell_type"] == "unassigned"
+    assert cell_annotations[1, "cell_type"] == "B_cell"
+
+
+def test_high_flags_include_negative_markers() -> None:
+    configuration = build_configuration(
+        [
+            {
+                "name": "helper_T",
+                "positive_markers": ["CD3e"],
+                "negative_markers": ["FOXP3"],
+            },
+        ]
+    )
+    cell_annotations = annotate_cells(
+        build_cell_features(CD3e=1000.0, FOXP3=0.0),
+        configuration,
+    )
+    assert "FOXP3_high" in cell_annotations.columns
 
 
 def test_missing_marker_column_fails_fast() -> None:


### PR DESCRIPTION
## Summary
Replaces the flat "exactly one match" cell typing logic with priority-based rule evaluation where the first matching rule wins. Adds optional `negative_markers` to annotation rules, enabling clean parent/subtype separation (e.g., helper T cell = CD3e+ CD4+ FOXP3-). Cells matching no rule are now labeled `unassigned`.

## Changes
- First-match-wins rule evaluation in `annotation.py`, evaluated in config order
- Optional `negative_markers` field on `CellTypeAnnotationRuleConfiguration` (defaults to empty list)
- `annotation_marker_names` property collects markers from both positive and negative lists
- `unassigned` label replaces `Other` for cells matching no rule
- Removed in-plot text labels from cell type map visualization (legend-only)
- Updated CRC33_01 config with hierarchical gating order and new subtypes (cytotoxic T cell, helper T cell, M2 macrophage)
- 5 new tests covering priority matching, negative markers, unassigned label, and `_high` flag inclusion

## Testing
`uv run pytest` — 39 tests pass, including 9 annotation tests.

## Closes
Closes #6