### PR TITLE
feat: add multi-patch sanity mode for analyzing multiple rois

### DIFF
--- a/configurations/CRC33_01.yaml
+++ b/configurations/CRC33_01.yaml
@@ -14,6 +14,7 @@ region_of_interest:
   patch_width_pixels: 2048
   patch_height_pixels: 2048
   candidate_patch_count: 12
+  analysis_patch_count: 3
   minimum_tissue_fraction: 0.35
   minimum_informative_channel_fraction: 0.5
   minimum_channel_signal_spread: 0.05

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -25,9 +25,20 @@ class RegionOfInterestConfiguration(BaseModel):
     patch_width_pixels: int
     patch_height_pixels: int
     candidate_patch_count: int = Field(default=12, ge=1)
+    analysis_patch_count: int = Field(default=1, ge=1)
     minimum_tissue_fraction: float = Field(default=0.35, ge=0.0, le=1.0)
     minimum_informative_channel_fraction: float = Field(default=0.5, ge=0.0, le=1.0)
     minimum_channel_signal_spread: float = Field(default=0.05, ge=0.0, le=1.0)
+
+    @model_validator(mode="after")
+    def validate_analysis_patch_count(self) -> "RegionOfInterestConfiguration":
+        """Ensure the number of patches to analyze does not exceed the candidate pool."""
+        if self.analysis_patch_count > self.candidate_patch_count:
+            raise ValueError(
+                "region_of_interest.analysis_patch_count must not exceed "
+                "region_of_interest.candidate_patch_count."
+            )
+        return self
 
 
 class AutofluorescenceSubtractionConfiguration(BaseModel):

--- a/src/data_models.py
+++ b/src/data_models.py
@@ -31,3 +31,9 @@ class SlideMetadata:
     pixel_size_x_micrometers: float
     pixel_size_y_micrometers: float
     marker_names: list[str]
+
+
+@dataclass(frozen=True)
+class PatchEntry:
+    patch_id: str
+    region_of_interest: RegionOfInterestBox

--- a/src/io.py
+++ b/src/io.py
@@ -14,7 +14,7 @@ from matplotlib.colors import ListedColormap
 from matplotlib.lines import Line2D
 from skimage import color
 
-from src.data_models import RegionOfInterestBox, SlideMetadata
+from src.data_models import PatchEntry, RegionOfInterestBox, SlideMetadata
 
 if TYPE_CHECKING:
     from src.configuration import ApplicationConfiguration
@@ -26,6 +26,72 @@ def ensure_directory(path: Path) -> Path:
     """Create the directory and any missing parents, returning the path."""
     path.mkdir(parents=True, exist_ok=True)
     return path
+
+
+def format_patch_identifier(patch_index: int) -> str:
+    """Return the zero-padded patch identifier used for per-patch output directories."""
+    return f"patch_{patch_index:03d}"
+
+
+def patch_output_directory(
+    sample_output_directory: Path,
+    patch_id: str,
+) -> Path:
+    """Return the per-patch output subdirectory path under a sample output directory."""
+    return sample_output_directory / patch_id
+
+
+def write_patches_manifest(
+    path: Path,
+    sample_identifier: str,
+    slide_metadata: SlideMetadata,
+    patch_entries: list[PatchEntry],
+) -> Path:
+    """Write the top-level patches manifest describing the selected patches."""
+    payload: dict[str, Any] = {
+        "sample_identifier": sample_identifier,
+        "pixel_size_x_micrometers": slide_metadata.pixel_size_x_micrometers,
+        "pixel_size_y_micrometers": slide_metadata.pixel_size_y_micrometers,
+        "marker_names": slide_metadata.marker_names,
+        "patches": [
+            {
+                "patch_id": entry.patch_id,
+                "x_pixels": entry.region_of_interest.x_pixels,
+                "y_pixels": entry.region_of_interest.y_pixels,
+                "width_pixels": entry.region_of_interest.width_pixels,
+                "height_pixels": entry.region_of_interest.height_pixels,
+            }
+            for entry in patch_entries
+        ],
+    }
+    write_yaml_file(path, payload)
+    return path
+
+
+def read_patches_manifest(path: Path) -> dict[str, Any]:
+    """Read the top-level patches manifest back into a dictionary."""
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Patches manifest not found at {path}. Run the select-roi stage first."
+        )
+    with path.open("r", encoding="utf-8") as file_handle:
+        return yaml.safe_load(file_handle)
+
+
+def parse_patch_entries(manifest_payload: dict[str, Any]) -> list[PatchEntry]:
+    """Build PatchEntry values from a parsed manifest dictionary."""
+    return [
+        PatchEntry(
+            patch_id=entry["patch_id"],
+            region_of_interest=RegionOfInterestBox(
+                x_pixels=int(entry["x_pixels"]),
+                y_pixels=int(entry["y_pixels"]),
+                width_pixels=int(entry["width_pixels"]),
+                height_pixels=int(entry["height_pixels"]),
+            ),
+        )
+        for entry in manifest_payload["patches"]
+    ]
 
 
 def read_marker_names(path: Path) -> list[str]:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -8,17 +8,20 @@ from pathlib import Path
 import numpy as np
 import polars as pl
 import tifffile
-import yaml
 
 from src.annotation import annotate_cells
 from src.configuration import ApplicationConfiguration
 from src.constants import STAGES
-from src.data_models import RegionOfInterestBox
+from src.data_models import PatchEntry, SlideMetadata
 from src.io import (
     build_marker_name_to_index,
     ensure_directory,
+    format_patch_identifier,
     load_slide_metadata,
+    parse_patch_entries,
+    patch_output_directory,
     read_histology_region_of_interest,
+    read_patches_manifest,
     read_readouts_region_of_interest,
     save_cell_assignment_map,
     save_preprocessing_comparison,
@@ -26,12 +29,16 @@ from src.io import (
     write_csv,
     write_image_stack,
     write_label_array,
+    write_patches_manifest,
     write_yaml_file,
 )
 from src.preprocessing import preprocess_region_of_interest_patch
 from src.quantification import quantify_cells_in_region_of_interest
 from src.region_of_interest import choose_region_of_interest
-from src.segmentation import segment_cells_from_marker_images
+from src.segmentation import (
+    build_segmentation_model,
+    segment_cells_from_marker_images,
+)
 from src.spatial_analysis import compute_spatial_analysis
 
 
@@ -59,8 +66,8 @@ def run_select_roi(
     configuration: ApplicationConfiguration,
     logger: logging.Logger,
 ) -> None:
-    """Select the best patch from the slide and write the raw patch and ROI metadata."""
-    output_directory = ensure_directory(configuration.sample_output_directory)
+    """Select non-overlapping analysis patches and write the manifest and per-patch ROI files."""
+    sample_output_directory = ensure_directory(configuration.sample_output_directory)
     slide_metadata = load_slide_metadata(configuration)
 
     logger.info("mode: %s", "patch")
@@ -71,245 +78,330 @@ def run_select_roi(
     logger.info("image_height_pixels: %s", slide_metadata.height_pixels)
     logger.info("pixel_size_x_micrometers: %s", slide_metadata.pixel_size_x_micrometers)
     logger.info("pixel_size_y_micrometers: %s", slide_metadata.pixel_size_y_micrometers)
+    logger.info(
+        "analysis_patch_count: %s",
+        configuration.region_of_interest.analysis_patch_count,
+    )
 
-    selected_roi, candidate_data_frame = choose_region_of_interest(
+    selected_regions_of_interest, candidate_data_frame = choose_region_of_interest(
         configuration, slide_metadata
     )
-    selected_candidate = candidate_data_frame.filter(pl.col("selected")).to_dicts()
-    if selected_candidate:
-        logger.info("region_of_interest_quality: %s", selected_candidate[0])
 
-    raw_patch = read_readouts_region_of_interest(
-        configuration.input_paths.readouts, selected_roi
-    )
-    write_image_stack(
-        output_directory / "raw_patch.tif",
-        raw_patch,
-        slide_metadata.marker_names,
+    write_csv(
+        candidate_data_frame,
+        sample_output_directory / "candidate_patches.csv",
     )
 
-    if configuration.input_paths.histology:
-        histology_patch = read_histology_region_of_interest(
-            configuration.input_paths.histology, selected_roi
+    patch_entries = [
+        PatchEntry(
+            patch_id=format_patch_identifier(patch_index),
+            region_of_interest=region_of_interest,
         )
-        tifffile.imwrite(
-            output_directory / "histology_patch.tif",
-            histology_patch,
-        )
+        for patch_index, region_of_interest in enumerate(selected_regions_of_interest)
+    ]
 
-    write_yaml_file(
-        output_directory / "roi_metadata.yaml",
-        {
-            **asdict(selected_roi),
-            "pixel_size_x_micrometers": slide_metadata.pixel_size_x_micrometers,
-            "pixel_size_y_micrometers": slide_metadata.pixel_size_y_micrometers,
-            "marker_names": slide_metadata.marker_names,
-        },
+    write_patches_manifest(
+        sample_output_directory / "patches_manifest.yaml",
+        configuration.sample_identifier,
+        slide_metadata,
+        patch_entries,
     )
 
-    logger.info("selected_region_of_interest: %s", asdict(selected_roi))
+    for patch_entry in patch_entries:
+        _write_patch_inputs(
+            configuration,
+            slide_metadata,
+            patch_entry,
+            sample_output_directory,
+            logger,
+        )
 
 
 def run_preprocess(
     configuration: ApplicationConfiguration,
     logger: logging.Logger,
 ) -> None:
-    """Subtract autofluorescence from the raw patch and save the corrected stack."""
-    output_directory = configuration.sample_output_directory
-    roi_metadata = _load_roi_metadata(output_directory)
-    marker_names = roi_metadata["marker_names"]
+    """Subtract autofluorescence from every patch and save the corrected stacks."""
+    manifest_payload, patch_entries = _load_manifest_entries(configuration)
+    marker_names = manifest_payload["marker_names"]
 
-    raw_patch = tifffile.imread(output_directory / "raw_patch.tif")
+    for patch_entry in patch_entries:
+        patch_directory = patch_output_directory(
+            configuration.sample_output_directory, patch_entry.patch_id
+        )
+        raw_patch = tifffile.imread(patch_directory / "raw_patch.tif")
+        patch_seed = derive_patch_seed(
+            configuration.sample_identifier,
+            _patch_index_from_id(patch_entry.patch_id),
+        )
+        preprocessing_result = preprocess_region_of_interest_patch(
+            raw_patch,
+            marker_names,
+            configuration,
+            patch_seed,
+        )
 
-    random_seed = zlib.crc32(configuration.sample_identifier.encode("utf-8"))
-    preprocessing_result = preprocess_region_of_interest_patch(
-        raw_patch,
-        marker_names,
-        configuration,
-        random_seed,
-    )
+        write_image_stack(
+            patch_directory / "corrected_patch.tif",
+            preprocessing_result.corrected_image_stack,
+            marker_names,
+        )
 
-    write_image_stack(
-        output_directory / "corrected_patch.tif",
-        preprocessing_result.corrected_image_stack,
-        marker_names,
-    )
+        marker_name_to_index = build_marker_name_to_index(marker_names)
+        comparison_index = marker_name_to_index[
+            configuration.channels.cytoplasmic_marker
+        ]
+        save_preprocessing_comparison(
+            raw_patch[comparison_index],
+            preprocessing_result.corrected_image_stack[comparison_index],
+            configuration.channels.cytoplasmic_marker,
+            patch_directory / "preprocessing_comparison.png",
+        )
 
-    marker_name_to_index = build_marker_name_to_index(marker_names)
-    comparison_index = marker_name_to_index[configuration.channels.cytoplasmic_marker]
-    save_preprocessing_comparison(
-        raw_patch[comparison_index],
-        preprocessing_result.corrected_image_stack[comparison_index],
-        configuration.channels.cytoplasmic_marker,
-        output_directory / "preprocessing_comparison.png",
-    )
-
-    logger.info("preprocessing complete")
+        logger.info("preprocessing complete: %s", patch_entry.patch_id)
 
 
 def run_segment(
     configuration: ApplicationConfiguration,
     logger: logging.Logger,
 ) -> None:
-    """Segment cells from the corrected patch and write the label mask and overlay."""
-    output_directory = configuration.sample_output_directory
-    roi_metadata = _load_roi_metadata(output_directory)
-    marker_name_to_index = build_marker_name_to_index(roi_metadata["marker_names"])
+    """Segment cells for every patch, building the Cellpose model once and reusing it."""
+    manifest_payload, patch_entries = _load_manifest_entries(configuration)
+    marker_name_to_index = build_marker_name_to_index(manifest_payload["marker_names"])
+    segmentation_model = build_segmentation_model(configuration)
 
-    corrected_patch = tifffile.imread(output_directory / "corrected_patch.tif")
-    nuclear_index = marker_name_to_index[configuration.channels.nuclear_marker]
-    cytoplasmic_index = marker_name_to_index[configuration.channels.cytoplasmic_marker]
+    for patch_entry in patch_entries:
+        patch_directory = patch_output_directory(
+            configuration.sample_output_directory, patch_entry.patch_id
+        )
+        corrected_patch = tifffile.imread(patch_directory / "corrected_patch.tif")
+        nuclear_index = marker_name_to_index[configuration.channels.nuclear_marker]
+        cytoplasmic_index = marker_name_to_index[
+            configuration.channels.cytoplasmic_marker
+        ]
 
-    segmentation_result = segment_cells_from_marker_images(
-        corrected_patch[nuclear_index],
-        corrected_patch[cytoplasmic_index],
-        configuration,
-    )
+        segmentation_result = segment_cells_from_marker_images(
+            corrected_patch[nuclear_index],
+            corrected_patch[cytoplasmic_index],
+            configuration,
+            segmentation_model,
+        )
 
-    write_label_array(
-        output_directory / "segmentation_mask.npy",
-        segmentation_result.cell_labels,
-    )
+        write_label_array(
+            patch_directory / "segmentation_mask.npy",
+            segmentation_result.cell_labels,
+        )
 
-    histology_path = output_directory / "histology_patch.tif"
-    background_image = (
-        tifffile.imread(histology_path)
-        if histology_path.exists()
-        else corrected_patch[cytoplasmic_index]
-    )
-    save_segmentation_overlay_image(
-        background_image,
-        segmentation_result.cell_labels,
-        output_directory / "segmentation_overlay.tif",
-    )
+        histology_path = patch_directory / "histology_patch.tif"
+        background_image = (
+            tifffile.imread(histology_path)
+            if histology_path.exists()
+            else corrected_patch[cytoplasmic_index]
+        )
+        save_segmentation_overlay_image(
+            background_image,
+            segmentation_result.cell_labels,
+            patch_directory / "segmentation_overlay.tif",
+        )
 
-    logger.info(
-        "segmentation complete: %d cells",
-        int(segmentation_result.cell_labels.max()),
-    )
+        logger.info(
+            "segmentation complete: %s, %d cells",
+            patch_entry.patch_id,
+            int(segmentation_result.cell_labels.max()),
+        )
 
 
 def run_quantify(
     configuration: ApplicationConfiguration,
     logger: logging.Logger,
 ) -> None:
-    """Measure per-cell morphology and marker intensities and write cell_features.csv."""
-    output_directory = configuration.sample_output_directory
-    roi_metadata = _load_roi_metadata(output_directory)
-    marker_names = roi_metadata["marker_names"]
+    """Measure per-cell features and write cell_features.csv for every patch."""
+    manifest_payload, patch_entries = _load_manifest_entries(configuration)
+    marker_names = manifest_payload["marker_names"]
     marker_name_to_index = build_marker_name_to_index(marker_names)
-
-    corrected_patch = tifffile.imread(output_directory / "corrected_patch.tif")
-    label_image = np.load(output_directory / "segmentation_mask.npy")
-
-    region_of_interest = RegionOfInterestBox(
-        x_pixels=roi_metadata["x_pixels"],
-        y_pixels=roi_metadata["y_pixels"],
-        width_pixels=roi_metadata["width_pixels"],
-        height_pixels=roi_metadata["height_pixels"],
-    )
-
     autofluorescence_marker = configuration.channels.autofluorescence_marker
     biological_marker_names = [
         name for name in marker_names if name != autofluorescence_marker
     ]
-    intensity_image_by_marker = {
-        marker_name: corrected_patch[marker_name_to_index[marker_name]].astype(float)
-        for marker_name in biological_marker_names
-    }
+    pixel_size_x_micrometers = float(manifest_payload["pixel_size_x_micrometers"])
+    pixel_size_y_micrometers = float(manifest_payload["pixel_size_y_micrometers"])
 
-    cell_features = quantify_cells_in_region_of_interest(
-        label_image,
-        intensity_image_by_marker,
-        biological_marker_names,
-        region_of_interest,
-        roi_metadata["pixel_size_x_micrometers"],
-        roi_metadata["pixel_size_y_micrometers"],
-    )
+    for patch_entry in patch_entries:
+        patch_directory = patch_output_directory(
+            configuration.sample_output_directory, patch_entry.patch_id
+        )
+        corrected_patch = tifffile.imread(patch_directory / "corrected_patch.tif")
+        label_image = np.load(patch_directory / "segmentation_mask.npy")
 
-    write_csv(
-        cell_features,
-        output_directory / "cell_features.csv",
-    )
+        intensity_image_by_marker = {
+            marker_name: corrected_patch[marker_name_to_index[marker_name]].astype(
+                float
+            )
+            for marker_name in biological_marker_names
+        }
 
-    logger.info("quantification complete: %d cells", cell_features.height)
+        cell_features = quantify_cells_in_region_of_interest(
+            label_image,
+            intensity_image_by_marker,
+            biological_marker_names,
+            patch_entry.region_of_interest,
+            pixel_size_x_micrometers,
+            pixel_size_y_micrometers,
+        )
+
+        write_csv(
+            cell_features,
+            patch_directory / "cell_features.csv",
+        )
+
+        logger.info(
+            "quantification complete: %s, %d cells",
+            patch_entry.patch_id,
+            cell_features.height,
+        )
 
 
 def run_annotate(
     configuration: ApplicationConfiguration,
     logger: logging.Logger,
 ) -> None:
-    """Assign cell type labels from quantified features and save annotations and map."""
-    output_directory = configuration.sample_output_directory
-    cell_features = pl.read_csv(output_directory / "cell_features.csv")
+    """Assign cell type labels for every patch and save annotations and maps."""
+    _, patch_entries = _load_manifest_entries(configuration)
 
-    cell_annotations = annotate_cells(
-        cell_features,
-        configuration,
-    )
+    for patch_entry in patch_entries:
+        patch_directory = patch_output_directory(
+            configuration.sample_output_directory, patch_entry.patch_id
+        )
+        cell_features = pl.read_csv(patch_directory / "cell_features.csv")
 
-    write_csv(
-        cell_annotations,
-        output_directory / "cell_annotations.csv",
-    )
+        cell_annotations = annotate_cells(
+            cell_features,
+            configuration,
+        )
 
-    save_cell_assignment_map(
-        cell_annotations,
-        "cell_type",
-        "Cell type map",
-        output_directory / "cell_type_map.png",
-    )
+        write_csv(
+            cell_annotations,
+            patch_directory / "cell_annotations.csv",
+        )
 
-    logger.info("annotation complete")
+        save_cell_assignment_map(
+            cell_annotations,
+            "cell_type",
+            "Cell type map",
+            patch_directory / "cell_type_map.png",
+        )
+
+        logger.info("annotation complete: %s", patch_entry.patch_id)
 
 
 def run_spatial(
     configuration: ApplicationConfiguration,
     logger: logging.Logger,
 ) -> None:
-    """Compute spatial neighborhoods, domains, and adjacency enrichment metrics."""
-    output_directory = configuration.sample_output_directory
-    cell_annotations = pl.read_csv(output_directory / "cell_annotations.csv")
+    """Compute spatial neighborhoods, domains, and adjacency metrics for every patch."""
+    _, patch_entries = _load_manifest_entries(configuration)
 
-    if "spatial_domain" in cell_annotations.columns:
-        cell_annotations = cell_annotations.drop("spatial_domain")
-
-    random_seed = zlib.crc32(configuration.sample_identifier.encode("utf-8"))
-    spatial_analysis_result = compute_spatial_analysis(
-        cell_annotations,
-        configuration,
-        random_seed,
-    )
-
-    write_csv(
-        spatial_analysis_result.cell_annotations_with_domains,
-        output_directory / "cell_annotations.csv",
-    )
-    write_csv(
-        spatial_analysis_result.spatial_metrics,
-        output_directory / "spatial_metrics.csv",
-    )
-
-    save_cell_assignment_map(
-        spatial_analysis_result.cell_annotations_with_domains,
-        "spatial_domain",
-        "Spatial domain map",
-        output_directory / "spatial_domain_map.png",
-    )
-
-    logger.info("spatial analysis complete")
-
-
-def _load_roi_metadata(output_directory: Path) -> dict:
-    """Load ROI metadata from the YAML file written by the select-roi stage."""
-    metadata_path = output_directory / "roi_metadata.yaml"
-    if not metadata_path.exists():
-        raise FileNotFoundError(
-            f"ROI metadata not found at {metadata_path}. "
-            "Run the select-roi stage first."
+    for patch_entry in patch_entries:
+        patch_directory = patch_output_directory(
+            configuration.sample_output_directory, patch_entry.patch_id
         )
-    with metadata_path.open("r", encoding="utf-8") as file_handle:
-        return yaml.safe_load(file_handle)
+        cell_annotations = pl.read_csv(patch_directory / "cell_annotations.csv")
+
+        if "spatial_domain" in cell_annotations.columns:
+            cell_annotations = cell_annotations.drop("spatial_domain")
+
+        patch_seed = derive_patch_seed(
+            configuration.sample_identifier,
+            _patch_index_from_id(patch_entry.patch_id),
+        )
+        spatial_analysis_result = compute_spatial_analysis(
+            cell_annotations,
+            configuration,
+            patch_seed,
+        )
+
+        write_csv(
+            spatial_analysis_result.cell_annotations_with_domains,
+            patch_directory / "cell_annotations.csv",
+        )
+        write_csv(
+            spatial_analysis_result.spatial_metrics,
+            patch_directory / "spatial_metrics.csv",
+        )
+
+        save_cell_assignment_map(
+            spatial_analysis_result.cell_annotations_with_domains,
+            "spatial_domain",
+            "Spatial domain map",
+            patch_directory / "spatial_domain_map.png",
+        )
+
+        logger.info("spatial analysis complete: %s", patch_entry.patch_id)
+
+
+def derive_patch_seed(sample_identifier: str, patch_index: int) -> int:
+    """Derive a deterministic RNG seed unique to a (sample_identifier, patch_index) pair."""
+    return zlib.crc32(f"{sample_identifier}:patch_{patch_index:03d}".encode("utf-8"))
+
+
+def _write_patch_inputs(
+    configuration: ApplicationConfiguration,
+    slide_metadata: SlideMetadata,
+    patch_entry: PatchEntry,
+    sample_output_directory: Path,
+    logger: logging.Logger,
+) -> None:
+    """Write per-patch raw inputs (raw_patch.tif, optional histology, roi_metadata.yaml)."""
+    patch_directory = ensure_directory(
+        patch_output_directory(sample_output_directory, patch_entry.patch_id)
+    )
+
+    raw_patch = read_readouts_region_of_interest(
+        configuration.input_paths.readouts, patch_entry.region_of_interest
+    )
+    write_image_stack(
+        patch_directory / "raw_patch.tif",
+        raw_patch,
+        slide_metadata.marker_names,
+    )
+
+    if configuration.input_paths.histology:
+        histology_patch = read_histology_region_of_interest(
+            configuration.input_paths.histology, patch_entry.region_of_interest
+        )
+        tifffile.imwrite(
+            patch_directory / "histology_patch.tif",
+            histology_patch,
+        )
+
+    write_yaml_file(
+        patch_directory / "roi_metadata.yaml",
+        {
+            "patch_id": patch_entry.patch_id,
+            **asdict(patch_entry.region_of_interest),
+        },
+    )
+
+    logger.info(
+        "selected_region_of_interest: %s %s",
+        patch_entry.patch_id,
+        asdict(patch_entry.region_of_interest),
+    )
+
+
+def _load_manifest_entries(
+    configuration: ApplicationConfiguration,
+) -> tuple[dict, list[PatchEntry]]:
+    """Load the patches manifest and return both the raw payload and parsed patch entries."""
+    manifest_path = configuration.sample_output_directory / "patches_manifest.yaml"
+    manifest_payload = read_patches_manifest(manifest_path)
+    patch_entries = parse_patch_entries(manifest_payload)
+    return manifest_payload, patch_entries
+
+
+def _patch_index_from_id(patch_id: str) -> int:
+    """Parse the integer index out of a patch identifier like 'patch_003'."""
+    return int(patch_id.rsplit("_", 1)[-1])
 
 
 _STAGE_FUNCTIONS = {

--- a/src/region_of_interest.py
+++ b/src/region_of_interest.py
@@ -20,8 +20,8 @@ from src.io import (
 def choose_region_of_interest(
     configuration: ApplicationConfiguration,
     slide_metadata: SlideMetadata,
-) -> tuple[RegionOfInterestBox, pl.DataFrame]:
-    """Select the highest-quality candidate patch from the slide as the analysis ROI."""
+) -> tuple[list[RegionOfInterestBox], pl.DataFrame]:
+    """Select the top non-overlapping analysis patches from the scored candidate pool."""
     validate_region_of_interest_bounds(
         configuration,
         slide_metadata,
@@ -41,15 +41,34 @@ def choose_region_of_interest(
         )
         for region_of_interest in candidate_regions_of_interest
     ]
-    candidate_data_frame = build_candidate_data_frame(candidate_rows)
-    selected_row = candidate_data_frame.row(0, named=True)
-    selected_region_of_interest = RegionOfInterestBox(
-        x_pixels=int(selected_row["x_pixels"]),
-        y_pixels=int(selected_row["y_pixels"]),
-        width_pixels=int(selected_row["width_pixels"]),
-        height_pixels=int(selected_row["height_pixels"]),
+    sorted_candidate_data_frame = sort_candidate_data_frame(candidate_rows)
+    selected_row_indices = select_non_overlapping_top_rows(
+        sorted_candidate_data_frame,
+        configuration.region_of_interest.analysis_patch_count,
     )
-    return selected_region_of_interest, candidate_data_frame
+    candidate_data_frame = mark_selected_rows(
+        sorted_candidate_data_frame,
+        selected_row_indices,
+    )
+    selected_regions_of_interest = [
+        build_region_of_interest_box_from_row(
+            candidate_data_frame.row(row_index, named=True)
+        )
+        for row_index in selected_row_indices
+    ]
+    return selected_regions_of_interest, candidate_data_frame
+
+
+def build_region_of_interest_box_from_row(
+    row: dict[str, object],
+) -> RegionOfInterestBox:
+    """Build a RegionOfInterestBox from a candidate dataframe row."""
+    return RegionOfInterestBox(
+        x_pixels=int(row["x_pixels"]),
+        y_pixels=int(row["y_pixels"]),
+        width_pixels=int(row["width_pixels"]),
+        height_pixels=int(row["height_pixels"]),
+    )
 
 
 def build_candidate_row(
@@ -94,20 +113,77 @@ def passes_quality_thresholds(
     )
 
 
-def build_candidate_data_frame(
+def sort_candidate_data_frame(
     candidate_rows: list[dict[str, object]],
 ) -> pl.DataFrame:
-    """Sort candidates by quality and mark the top one as selected."""
-    candidate_data_frame = pl.DataFrame(candidate_rows).sort(
+    """Sort candidate rows by pass/quality order without marking selections."""
+    return pl.DataFrame(candidate_rows).sort(
         ["passes_quality_thresholds", "quality_score"],
         descending=[True, True],
     )
-    return candidate_data_frame.with_columns(
+
+
+def select_non_overlapping_top_rows(
+    sorted_candidate_data_frame: pl.DataFrame,
+    analysis_patch_count: int,
+) -> list[int]:
+    """Greedily pick the top N candidate row indices whose bounding boxes do not overlap."""
+    selected_row_indices: list[int] = []
+    selected_boxes: list[RegionOfInterestBox] = []
+    for row_index in range(sorted_candidate_data_frame.height):
+        if len(selected_row_indices) == analysis_patch_count:
+            break
+        candidate_box = build_region_of_interest_box_from_row(
+            sorted_candidate_data_frame.row(row_index, named=True)
+        )
+        if any(
+            boxes_overlap(candidate_box, selected_box)
+            for selected_box in selected_boxes
+        ):
+            continue
+        selected_row_indices.append(row_index)
+        selected_boxes.append(candidate_box)
+    if len(selected_row_indices) < analysis_patch_count:
+        raise ValueError(
+            "Unable to select "
+            f"{analysis_patch_count} non-overlapping patches from the candidate pool. "
+            "Increase region_of_interest.candidate_patch_count or decrease "
+            "region_of_interest.analysis_patch_count."
+        )
+    return selected_row_indices
+
+
+def mark_selected_rows(
+    sorted_candidate_data_frame: pl.DataFrame,
+    selected_row_indices: list[int],
+) -> pl.DataFrame:
+    """Return a new dataframe with a boolean 'selected' column flagging the given rows."""
+    selected_index_set = set(selected_row_indices)
+    return sorted_candidate_data_frame.with_columns(
         pl.Series(
             "selected",
-            [row_index == 0 for row_index in range(candidate_data_frame.height)],
+            [
+                row_index in selected_index_set
+                for row_index in range(sorted_candidate_data_frame.height)
+            ],
         )
     )
+
+
+def boxes_overlap(
+    first_box: RegionOfInterestBox,
+    second_box: RegionOfInterestBox,
+) -> bool:
+    """Return True if two bounding boxes share any pixel (half-open intervals)."""
+    horizontal_overlap = (
+        first_box.x_pixels < second_box.x_end_pixels
+        and second_box.x_pixels < first_box.x_end_pixels
+    )
+    vertical_overlap = (
+        first_box.y_pixels < second_box.y_end_pixels
+        and second_box.y_pixels < first_box.y_end_pixels
+    )
+    return horizontal_overlap and vertical_overlap
 
 
 def validate_region_of_interest_bounds(

--- a/src/segmentation.py
+++ b/src/segmentation.py
@@ -14,16 +14,23 @@ class SegmentationResult:
     cell_labels: np.ndarray
 
 
+def build_segmentation_model(
+    configuration: ApplicationConfiguration,
+) -> CellposeModel:
+    """Construct a Cellpose-SAM model once so it can be reused across patches."""
+    return CellposeModel(
+        pretrained_model="cpsam",
+        gpu=configuration.segmentation.use_gpu,
+    )
+
+
 def segment_cells_from_marker_images(
     nuclear_image: np.ndarray,
     cytoplasmic_image: np.ndarray,
     configuration: ApplicationConfiguration,
+    model: CellposeModel,
 ) -> SegmentationResult:
     """Segment cells using Cellpose-SAM with nuclear and cytoplasmic channels."""
-    model = CellposeModel(
-        pretrained_model="cpsam",
-        gpu=configuration.segmentation.use_gpu,
-    )
     image_stack = np.stack(
         [cytoplasmic_image, nuclear_image],
         axis=-1,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -142,3 +142,29 @@ def test_cytoplasmic_marker_must_differ_from_nuclear_marker(tmp_path: Path) -> N
     configuration_path = write_configuration_file(tmp_path, configuration_dictionary)
     with pytest.raises(ValueError):
         load_configuration(configuration_path)
+
+
+def test_analysis_patch_count_defaults_to_one(tmp_path: Path) -> None:
+    configuration_dictionary = base_configuration_dictionary(tmp_path)
+    configuration_path = write_configuration_file(tmp_path, configuration_dictionary)
+    configuration = load_configuration(configuration_path)
+    assert configuration.region_of_interest.analysis_patch_count == 1
+
+
+def test_analysis_patch_count_rejects_values_below_one(tmp_path: Path) -> None:
+    configuration_dictionary = base_configuration_dictionary(tmp_path)
+    configuration_dictionary["region_of_interest"]["analysis_patch_count"] = 0
+    configuration_path = write_configuration_file(tmp_path, configuration_dictionary)
+    with pytest.raises(ValueError):
+        load_configuration(configuration_path)
+
+
+def test_analysis_patch_count_cannot_exceed_candidate_patch_count(
+    tmp_path: Path,
+) -> None:
+    configuration_dictionary = base_configuration_dictionary(tmp_path)
+    configuration_dictionary["region_of_interest"]["candidate_patch_count"] = 3
+    configuration_dictionary["region_of_interest"]["analysis_patch_count"] = 5
+    configuration_path = write_configuration_file(tmp_path, configuration_dictionary)
+    with pytest.raises(ValueError):
+        load_configuration(configuration_path)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import polars as pl
+import pytest
+
+from src import pipeline as pipeline_module
+from src.data_models import PatchEntry, RegionOfInterestBox, SlideMetadata
+from src.io import parse_patch_entries, read_patches_manifest, write_patches_manifest
+
+
+def build_dummy_configuration(
+    sample_output_root: Path,
+    sample_identifier: str = "TEST_SAMPLE",
+) -> SimpleNamespace:
+    input_paths = SimpleNamespace(
+        readouts=sample_output_root / "readouts.tiff",
+        histology=None,
+        markers=sample_output_root / "markers.csv",
+    )
+    configuration = SimpleNamespace(
+        sample_identifier=sample_identifier,
+        input_paths=input_paths,
+        sample_output_directory=sample_output_root / sample_identifier,
+        channels=SimpleNamespace(
+            nuclear_marker="Hoechst",
+            cytoplasmic_marker="Pan-CK",
+            autofluorescence_marker="AF1",
+        ),
+        region_of_interest=SimpleNamespace(
+            analysis_patch_count=2,
+            candidate_patch_count=4,
+            patch_width_pixels=32,
+            patch_height_pixels=24,
+        ),
+    )
+    return configuration
+
+
+def build_slide_metadata() -> SlideMetadata:
+    return SlideMetadata(
+        readouts_path=Path("readouts.tiff"),
+        histology_path=None,
+        width_pixels=200,
+        height_pixels=100,
+        pixel_size_x_micrometers=1.0,
+        pixel_size_y_micrometers=1.0,
+        marker_names=["Hoechst", "AF1", "Pan-CK", "CD45"],
+    )
+
+
+def test_derive_patch_seed_is_deterministic_and_distinct() -> None:
+    first_seed = pipeline_module.derive_patch_seed("SAMPLE_A", 0)
+    same_seed = pipeline_module.derive_patch_seed("SAMPLE_A", 0)
+    other_patch_seed = pipeline_module.derive_patch_seed("SAMPLE_A", 1)
+    other_sample_seed = pipeline_module.derive_patch_seed("SAMPLE_B", 0)
+
+    assert first_seed == same_seed
+    assert first_seed != other_patch_seed
+    assert first_seed != other_sample_seed
+
+
+def test_patch_index_is_parsed_from_identifier() -> None:
+    assert pipeline_module._patch_index_from_id("patch_000") == 0
+    assert pipeline_module._patch_index_from_id("patch_007") == 7
+    assert pipeline_module._patch_index_from_id("patch_042") == 42
+
+
+def test_patches_manifest_roundtrip(tmp_path: Path) -> None:
+    slide_metadata = build_slide_metadata()
+    patch_entries = [
+        PatchEntry(
+            patch_id="patch_000",
+            region_of_interest=RegionOfInterestBox(0, 0, 32, 24),
+        ),
+        PatchEntry(
+            patch_id="patch_001",
+            region_of_interest=RegionOfInterestBox(40, 0, 32, 24),
+        ),
+    ]
+    manifest_path = tmp_path / "patches_manifest.yaml"
+
+    write_patches_manifest(
+        manifest_path,
+        "TEST_SAMPLE",
+        slide_metadata,
+        patch_entries,
+    )
+
+    payload = read_patches_manifest(manifest_path)
+    assert payload["sample_identifier"] == "TEST_SAMPLE"
+    assert payload["marker_names"] == slide_metadata.marker_names
+    assert parse_patch_entries(payload) == patch_entries
+
+
+def test_run_select_roi_writes_manifest_and_per_patch_directories(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    configuration = build_dummy_configuration(tmp_path)
+    slide_metadata = build_slide_metadata()
+    selected_regions_of_interest = [
+        RegionOfInterestBox(0, 0, 32, 24),
+        RegionOfInterestBox(40, 0, 32, 24),
+    ]
+    candidate_data_frame = pl.DataFrame(
+        {
+            "x_pixels": [0, 40],
+            "y_pixels": [0, 0],
+            "width_pixels": [32, 32],
+            "height_pixels": [24, 24],
+            "quality_score": [0.9, 0.8],
+            "selected": [True, True],
+        }
+    )
+
+    monkeypatch.setattr(
+        pipeline_module,
+        "load_slide_metadata",
+        lambda _configuration: slide_metadata,
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "choose_region_of_interest",
+        lambda _configuration, _slide_metadata: (
+            selected_regions_of_interest,
+            candidate_data_frame,
+        ),
+    )
+    monkeypatch.setattr(
+        pipeline_module,
+        "read_readouts_region_of_interest",
+        lambda _path, _region: np.ones((4, 24, 32), dtype=np.float32),
+    )
+
+    logger = logging.getLogger("test_run_select_roi")
+
+    pipeline_module.run_select_roi(configuration, logger)
+
+    sample_directory = configuration.sample_output_directory
+    assert (sample_directory / "patches_manifest.yaml").exists()
+    assert (sample_directory / "candidate_patches.csv").exists()
+    assert (sample_directory / "patch_000" / "roi_metadata.yaml").exists()
+    assert (sample_directory / "patch_000" / "raw_patch.tif").exists()
+    assert (sample_directory / "patch_001" / "roi_metadata.yaml").exists()
+    assert (sample_directory / "patch_001" / "raw_patch.tif").exists()
+
+    manifest_payload = read_patches_manifest(sample_directory / "patches_manifest.yaml")
+    parsed_entries = parse_patch_entries(manifest_payload)
+    assert [entry.patch_id for entry in parsed_entries] == ["patch_000", "patch_001"]
+    assert parsed_entries[0].region_of_interest == selected_regions_of_interest[0]
+    assert parsed_entries[1].region_of_interest == selected_regions_of_interest[1]
+
+
+def test_run_segment_builds_cellpose_model_once_for_all_patches(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    configuration = build_dummy_configuration(tmp_path)
+    slide_metadata = build_slide_metadata()
+    sample_directory = configuration.sample_output_directory
+    sample_directory.mkdir(parents=True, exist_ok=True)
+
+    patch_entries = [
+        PatchEntry(
+            patch_id="patch_000",
+            region_of_interest=RegionOfInterestBox(0, 0, 32, 24),
+        ),
+        PatchEntry(
+            patch_id="patch_001",
+            region_of_interest=RegionOfInterestBox(40, 0, 32, 24),
+        ),
+    ]
+    write_patches_manifest(
+        sample_directory / "patches_manifest.yaml",
+        configuration.sample_identifier,
+        slide_metadata,
+        patch_entries,
+    )
+    corrected_patch = np.zeros((4, 24, 32), dtype=np.float32)
+
+    monkeypatch.setattr(
+        pipeline_module.tifffile,
+        "imread",
+        lambda _path: corrected_patch,
+    )
+
+    build_model_mock = MagicMock(return_value=MagicMock())
+    segment_mock = MagicMock(
+        return_value=SimpleNamespace(
+            cell_labels=np.zeros((24, 32), dtype=np.int32),
+        )
+    )
+    overlay_mock = MagicMock()
+    write_label_mock = MagicMock()
+
+    monkeypatch.setattr(pipeline_module, "build_segmentation_model", build_model_mock)
+    monkeypatch.setattr(
+        pipeline_module, "segment_cells_from_marker_images", segment_mock
+    )
+    monkeypatch.setattr(
+        pipeline_module, "save_segmentation_overlay_image", overlay_mock
+    )
+    monkeypatch.setattr(pipeline_module, "write_label_array", write_label_mock)
+
+    logger = logging.getLogger("test_run_segment")
+    pipeline_module.run_segment(configuration, logger)
+
+    build_model_mock.assert_called_once_with(configuration)
+    assert segment_mock.call_count == 2
+    assert write_label_mock.call_count == 2

--- a/tests/test_region_of_interest.py
+++ b/tests/test_region_of_interest.py
@@ -1,9 +1,11 @@
 from dataclasses import asdict
 
 import numpy as np
+import pytest
 
 from src.data_models import RegionOfInterestBox, SlideMetadata
 from src.region_of_interest import (
+    boxes_overlap,
     choose_region_of_interest,
     score_region_of_interest_patch,
 )
@@ -13,6 +15,7 @@ class DummyRegionOfInterestConfiguration:
     patch_width_pixels = 32
     patch_height_pixels = 24
     candidate_patch_count = 3
+    analysis_patch_count = 1
     minimum_tissue_fraction = 0.2
     minimum_informative_channel_fraction = 0.5
     minimum_channel_signal_spread = 0.05
@@ -54,15 +57,15 @@ def test_random_region_of_interest_is_deterministic_for_sample_identifier(
             (4, 24, 32), dtype=np.float32
         ),
     )
-    first_region_of_interest, first_candidates = choose_region_of_interest(
+    first_regions, first_candidates = choose_region_of_interest(
         DummyConfiguration(),
         slide_metadata,
     )
-    second_region_of_interest, second_candidates = choose_region_of_interest(
+    second_regions, second_candidates = choose_region_of_interest(
         DummyConfiguration(),
         slide_metadata,
     )
-    assert first_region_of_interest == second_region_of_interest
+    assert first_regions == second_regions
     assert first_candidates.to_dicts() == second_candidates.to_dicts()
 
 
@@ -74,10 +77,12 @@ def test_random_region_of_interest_respects_patch_bounds(monkeypatch) -> None:
             (4, 24, 32), dtype=np.float32
         ),
     )
-    region_of_interest, candidate_data_frame = choose_region_of_interest(
+    regions_of_interest, candidate_data_frame = choose_region_of_interest(
         DummyConfiguration(),
         slide_metadata,
     )
+    assert len(regions_of_interest) == 1
+    region_of_interest = regions_of_interest[0]
     assert 0 <= region_of_interest.x_pixels <= 48
     assert 0 <= region_of_interest.y_pixels <= 36
     assert (
@@ -88,8 +93,8 @@ def test_random_region_of_interest_respects_patch_bounds(monkeypatch) -> None:
 def test_high_quality_patch_outranks_sparse_patch(monkeypatch) -> None:
     candidate_regions_of_interest = [
         RegionOfInterestBox(0, 0, 32, 24),
-        RegionOfInterestBox(10, 10, 32, 24),
-        RegionOfInterestBox(20, 20, 32, 24),
+        RegionOfInterestBox(40, 0, 32, 24),
+        RegionOfInterestBox(80, 0, 32, 24),
     ]
 
     def fake_generate_candidates(*_arguments, **_keyword_arguments):
@@ -104,8 +109,8 @@ def test_high_quality_patch_outranks_sparse_patch(monkeypatch) -> None:
 
     patch_by_coordinate = {
         (0, 0): blank_patch,
-        (10, 10): low_quality_patch,
-        (20, 20): high_quality_patch,
+        (40, 0): low_quality_patch,
+        (80, 0): high_quality_patch,
     }
 
     def fake_read_patch(_path, region_of_interest):
@@ -121,11 +126,11 @@ def test_high_quality_patch_outranks_sparse_patch(monkeypatch) -> None:
         "src.region_of_interest.read_readouts_region_of_interest",
         fake_read_patch,
     )
-    region_of_interest, candidate_data_frame = choose_region_of_interest(
+    regions_of_interest, candidate_data_frame = choose_region_of_interest(
         DummyConfiguration(),
         build_slide_metadata(),
     )
-    assert region_of_interest == candidate_regions_of_interest[2]
+    assert regions_of_interest == [candidate_regions_of_interest[2]]
     selected_row = candidate_data_frame.filter(candidate_data_frame["selected"]).row(
         0, named=True
     )
@@ -142,7 +147,7 @@ def test_best_candidate_is_returned_when_no_patch_passes_thresholds(
 
     candidate_regions_of_interest = [
         RegionOfInterestBox(0, 0, 32, 24),
-        RegionOfInterestBox(10, 10, 32, 24),
+        RegionOfInterestBox(40, 0, 32, 24),
     ]
 
     weak_patch = np.zeros((4, 24, 32), dtype=np.float32)
@@ -153,7 +158,7 @@ def test_best_candidate_is_returned_when_no_patch_passes_thresholds(
 
     patch_by_coordinate = {
         (0, 0): weak_patch,
-        (10, 10): better_patch,
+        (40, 0): better_patch,
     }
 
     monkeypatch.setattr(
@@ -166,11 +171,11 @@ def test_best_candidate_is_returned_when_no_patch_passes_thresholds(
             (region_of_interest.x_pixels, region_of_interest.y_pixels)
         ],
     )
-    region_of_interest, candidate_data_frame = choose_region_of_interest(
+    regions_of_interest, candidate_data_frame = choose_region_of_interest(
         configuration,
         build_slide_metadata(),
     )
-    assert region_of_interest == candidate_regions_of_interest[1]
+    assert regions_of_interest == [candidate_regions_of_interest[1]]
     assert candidate_data_frame["passes_quality_thresholds"].to_list() == [False, False]
     assert candidate_data_frame["selected"].to_list() == [True, False]
 
@@ -209,3 +214,79 @@ def test_region_of_interest_box_as_dict() -> None:
         "width_pixels": 3,
         "height_pixels": 4,
     }
+
+
+def test_boxes_overlap_detects_shared_pixel() -> None:
+    box_a = RegionOfInterestBox(0, 0, 10, 10)
+    box_b = RegionOfInterestBox(5, 5, 10, 10)
+    assert boxes_overlap(box_a, box_b)
+
+
+def test_boxes_overlap_rejects_adjacent_boxes() -> None:
+    box_a = RegionOfInterestBox(0, 0, 10, 10)
+    box_b = RegionOfInterestBox(10, 0, 10, 10)
+    assert not boxes_overlap(box_a, box_b)
+
+
+def test_multi_patch_selects_top_n_non_overlapping_patches(monkeypatch) -> None:
+    configuration = DummyConfiguration()
+    configuration.region_of_interest.analysis_patch_count = 2
+    configuration.region_of_interest.candidate_patch_count = 4
+
+    candidate_regions_of_interest = [
+        RegionOfInterestBox(0, 0, 32, 24),
+        RegionOfInterestBox(5, 0, 32, 24),
+        RegionOfInterestBox(40, 0, 32, 24),
+        RegionOfInterestBox(80, 0, 32, 24),
+    ]
+    informative_patch = np.zeros((4, 24, 32), dtype=np.float32)
+    informative_patch[0, 5:15, 6:16] = 10.0
+    informative_patch[2, 3:12, 18:28] = 8.0
+    informative_patch[3, 12:20, 10:22] = 7.0
+
+    monkeypatch.setattr(
+        "src.region_of_interest.generate_candidate_regions_of_interest",
+        lambda *_arguments, **_keyword_arguments: candidate_regions_of_interest,
+    )
+    monkeypatch.setattr(
+        "src.region_of_interest.read_readouts_region_of_interest",
+        lambda *_arguments, **_keyword_arguments: informative_patch,
+    )
+    regions_of_interest, candidate_data_frame = choose_region_of_interest(
+        configuration,
+        build_slide_metadata(width_pixels=200, height_pixels=100),
+    )
+    assert len(regions_of_interest) == 2
+    for first, second in zip(regions_of_interest, regions_of_interest[1:]):
+        assert not boxes_overlap(first, second)
+    assert sum(candidate_data_frame["selected"].to_list()) == 2
+
+
+def test_multi_patch_raises_when_non_overlap_cannot_be_satisfied(monkeypatch) -> None:
+    configuration = DummyConfiguration()
+    configuration.region_of_interest.analysis_patch_count = 3
+    configuration.region_of_interest.candidate_patch_count = 3
+
+    candidate_regions_of_interest = [
+        RegionOfInterestBox(0, 0, 32, 24),
+        RegionOfInterestBox(5, 5, 32, 24),
+        RegionOfInterestBox(10, 10, 32, 24),
+    ]
+    informative_patch = np.zeros((4, 24, 32), dtype=np.float32)
+    informative_patch[0, 5:15, 6:16] = 10.0
+    informative_patch[2, 3:12, 18:28] = 8.0
+    informative_patch[3, 12:20, 10:22] = 7.0
+
+    monkeypatch.setattr(
+        "src.region_of_interest.generate_candidate_regions_of_interest",
+        lambda *_arguments, **_keyword_arguments: candidate_regions_of_interest,
+    )
+    monkeypatch.setattr(
+        "src.region_of_interest.read_readouts_region_of_interest",
+        lambda *_arguments, **_keyword_arguments: informative_patch,
+    )
+    with pytest.raises(ValueError, match="non-overlapping"):
+        choose_region_of_interest(
+            configuration,
+            build_slide_metadata(),
+        )

--- a/tests/test_segmentation.py
+++ b/tests/test_segmentation.py
@@ -2,7 +2,10 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from src.segmentation import segment_cells_from_marker_images
+from src.segmentation import (
+    build_segmentation_model,
+    segment_cells_from_marker_images,
+)
 
 
 class DummySegmentationConfiguration:
@@ -19,22 +22,24 @@ class DummyApplicationConfiguration:
     preprocessing = DummyPreprocessingConfiguration()
 
 
-@patch("src.segmentation.CellposeModel")
-def test_cellpose_returns_sequential_int32_labels(
-    mock_cellpose_class: MagicMock,
-) -> None:
+def build_mock_model_with_labels(labels: np.ndarray) -> MagicMock:
     mock_model = MagicMock()
-    mock_cellpose_class.return_value = mock_model
+    mock_model.eval.return_value = (labels, None, None)
+    return mock_model
+
+
+def test_cellpose_returns_sequential_int32_labels() -> None:
     mock_labels = np.array(
         [[0, 0, 5, 5], [0, 0, 5, 5], [3, 3, 0, 0], [3, 3, 0, 0]],
         dtype=np.int32,
     )
-    mock_model.eval.return_value = (mock_labels, None, None)
+    mock_model = build_mock_model_with_labels(mock_labels)
 
     result = segment_cells_from_marker_images(
         np.zeros((4, 4), dtype=np.float32),
         np.zeros((4, 4), dtype=np.float32),
         DummyApplicationConfiguration(),
+        mock_model,
     )
 
     assert result.cell_labels.dtype == np.int32
@@ -42,16 +47,14 @@ def test_cellpose_returns_sequential_int32_labels(
     assert unique_labels == {1, 2}
 
 
-@patch("src.segmentation.CellposeModel")
-def test_cellpose_called_without_channels(mock_cellpose_class: MagicMock) -> None:
-    mock_model = MagicMock()
-    mock_cellpose_class.return_value = mock_model
-    mock_model.eval.return_value = (np.zeros((4, 4), dtype=np.int32), None, None)
+def test_cellpose_called_without_channels() -> None:
+    mock_model = build_mock_model_with_labels(np.zeros((4, 4), dtype=np.int32))
 
     segment_cells_from_marker_images(
         np.zeros((4, 4), dtype=np.float32),
         np.zeros((4, 4), dtype=np.float32),
         DummyApplicationConfiguration(),
+        mock_model,
     )
 
     mock_model.eval.assert_called_once()
@@ -59,21 +62,48 @@ def test_cellpose_called_without_channels(mock_cellpose_class: MagicMock) -> Non
     assert "channels" not in call_kwargs.kwargs
 
 
-@patch("src.segmentation.CellposeModel")
-def test_cellpose_receives_diameter_and_gpu(mock_cellpose_class: MagicMock) -> None:
-    mock_model = MagicMock()
-    mock_cellpose_class.return_value = mock_model
-    mock_model.eval.return_value = (np.zeros((4, 4), dtype=np.int32), None, None)
+def test_cellpose_receives_diameter() -> None:
+    mock_model = build_mock_model_with_labels(np.zeros((4, 4), dtype=np.int32))
 
     segment_cells_from_marker_images(
         np.zeros((4, 4), dtype=np.float32),
         np.zeros((4, 4), dtype=np.float32),
         DummyApplicationConfiguration(),
+        mock_model,
     )
 
+    call_kwargs = mock_model.eval.call_args
+    assert call_kwargs.kwargs["diameter"] == 30.0
+
+
+@patch("src.segmentation.CellposeModel")
+def test_build_segmentation_model_passes_configuration(
+    mock_cellpose_class: MagicMock,
+) -> None:
+    build_segmentation_model(DummyApplicationConfiguration())
     mock_cellpose_class.assert_called_once_with(
         pretrained_model="cpsam",
         gpu=False,
     )
-    call_kwargs = mock_model.eval.call_args
-    assert call_kwargs.kwargs["diameter"] == 30.0
+
+
+@patch("src.segmentation.CellposeModel")
+def test_build_segmentation_model_called_once_for_multiple_patches(
+    mock_cellpose_class: MagicMock,
+) -> None:
+    mock_model = build_mock_model_with_labels(np.zeros((4, 4), dtype=np.int32))
+    mock_cellpose_class.return_value = mock_model
+
+    configuration = DummyApplicationConfiguration()
+    model = build_segmentation_model(configuration)
+
+    for _ in range(3):
+        segment_cells_from_marker_images(
+            np.zeros((4, 4), dtype=np.float32),
+            np.zeros((4, 4), dtype=np.float32),
+            configuration,
+            model,
+        )
+
+    mock_cellpose_class.assert_called_once()
+    assert mock_model.eval.call_count == 3


### PR DESCRIPTION
## Summary
Extends the patch pipeline so a single run can analyze multiple non-overlapping high-quality ROIs, letting users sanity-check result quality across distinct regions before committing to whole-slide mode. Each stage now iterates over all selected patches from a shared manifest, writing outputs to per-patch subdirectories.

## Changes
- Add `region_of_interest.analysis_patch_count` config field (default 1, must be ≤ `candidate_patch_count`).
- Rework ROI selection to pick the top N non-overlapping candidates, write a `patches_manifest.yaml`, and materialize each patch into its own `patch_NNN/` subdirectory with raw inputs and metadata.
- Restructure `pipeline.py` to a stage-outer/patch-inner loop so every stage reads the manifest and iterates patches.
- Lift Cellpose-SAM model construction into `build_segmentation_model`, built once per `run_segment` call and reused across patches.
- Add `PatchEntry` dataclass and manifest read/write helpers; add `derive_patch_seed` for per-patch deterministic seeding.
- Update `configurations/CRC33_01.yaml` to use `analysis_patch_count: 3`.

## Testing
- `uv run pytest` (56 tests passing, includes new `tests/test_pipeline.py` covering manifest round-trip, per-patch directory layout, seed determinism, and single-Cellpose-build guarantee).
- `uv run ruff check src/ tests/ main.py` clean; `uv run pre-commit run --all-files` passes.

## Closes
Closes #8.